### PR TITLE
fix(api): include anonymous contributors

### DIFF
--- a/apps/api/internal/service/image/service.go
+++ b/apps/api/internal/service/image/service.go
@@ -35,7 +35,7 @@ type GetImageParams struct {
 	Data            *model.RepositoryContributors
 }
 
-func (s *serviceImpl) GetImage(c context.Context, r *model.RepositoryContributors, options *renderer.RendererOptions) (model.FileHandle, error) {
+func (s *serviceImpl) GetImage(c context.Context, data *model.RepositoryContributors, options *renderer.RendererOptions) (model.FileHandle, error) {
 	ctx, span := tracing.Tracer().Start(c, "image.Service.GetImage")
 	defer span.End()
 	log := logger.FromContext(ctx)
@@ -54,7 +54,7 @@ func (s *serviceImpl) GetImage(c context.Context, r *model.RepositoryContributor
 	}
 	options.ItemSize = defaultItemSize
 
-	cacheKey := createImageCacheKey(r.Repository, options, "svg")
+	cacheKey := createImageCacheKey(data.Repository, options, "svg")
 	// restore cached image
 	cache, err := s.restoreCache(ctx, cacheKey)
 	if err != nil {
@@ -66,7 +66,7 @@ func (s *serviceImpl) GetImage(c context.Context, r *model.RepositoryContributor
 	}
 	s.sendCacheMissLog(ctx, cacheKey)
 	// render image
-	image, err := s.render(ctx, r, options)
+	image, err := s.render(ctx, data, options)
 	if err != nil {
 		return nil, err
 	}

--- a/libs/goutils/dataurl/resolver.go
+++ b/libs/goutils/dataurl/resolver.go
@@ -15,6 +15,7 @@ func ResolveImageDataURL(c context.Context, remoteURL string, imageSize int) (st
 	u, _ := url.Parse(remoteURL)
 	q := u.Query()
 	q.Set("size", fmt.Sprint(imageSize))
+	q.Set("s", fmt.Sprint(imageSize))
 	u.RawQuery = q.Encode()
 
 	client := httptrace.NewClient(http.DefaultTransport)

--- a/libs/goutils/renderer/.snapshots/TestRender_Snapshot.svg
+++ b/libs/goutils/renderer/.snapshots/TestRender_Snapshot.svg
@@ -13,9 +13,9 @@
 </defs>
 </svg>
 <svg x="68" y="0" width="64" height="64">\n<title>login2</title>
-<circle cx="32" cy="32" r="32" stroke="#c0c0c0" stroke-width="1" fill="url(#fill0)" />
+<circle cx="32" cy="32" r="32" stroke="#c0c0c0" stroke-width="1" fill="url(#fill1)" />
 <defs>
-<pattern id="fill0" x="0" y="0" width="64" height="64" patternUnits="userSpaceOnUse" >
+<pattern id="fill1" x="0" y="0" width="64" height="64" patternUnits="userSpaceOnUse" >
 <image x="0" y="0" width="64" height="64" xlink:href="avatar2" />
 </pattern>
 </defs>

--- a/libs/goutils/renderer/renderer.go
+++ b/libs/goutils/renderer/renderer.go
@@ -67,7 +67,7 @@ func (r *renderer) buildSVG(w io.Writer, data *model.RepositoryContributors) {
 		// nested <svg> is not supported in svgo
 		fmt.Fprintf(canvas.Writer, `<svg x="%d" y="%d" width="%d" height="%d">\n`, x, y, r.Options.ItemSize, r.Options.ItemSize)
 		{
-			fillId := fmt.Sprintf("fill%d", c.ID)
+			fillId := fmt.Sprintf("fill%d", i)
 			canvas.Title(c.Login)
 			canvas.Circle(r.Options.ItemSize/2, r.Options.ItemSize/2, r.Options.ItemSize/2, `stroke="#c0c0c0"`, `stroke-width="1"`, fmt.Sprintf(`fill="url(#%s)"`, fillId))
 			canvas.Def()

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:all:staging": "yarn build:all --configuration staging",
     "build:all:production": "yarn build:all --configuration production",
     "test": "nx test",
+    "test:u": "UPDATE_SNAPSHOTS=true yarn test",
     "test:ci": "nx run-many --target test --all --parallel",
     "format": "nx run-many --target format --parallel",
     "lint": "nx workspace-lint && nx run-many --target lint --parallel",


### PR DESCRIPTION
Relates #1124 

Before

<img width="956" alt="image" src="https://user-images.githubusercontent.com/1529180/184059597-a4a05a78-502a-4952-8af2-04fe34d43b49.png">

After

<img width="883" alt="image" src="https://user-images.githubusercontent.com/1529180/184059741-abe1e1a3-8612-4380-88bb-497186333169.png">


- Anonymous contributor's avatar image is resolved by using Gravatar. 