### PR TITLE
feat: add `itemSize` option

### DIFF
--- a/apps/api/internal/api/image/api.go
+++ b/apps/api/internal/api/image/api.go
@@ -57,6 +57,7 @@ func (api *API) Get(c *gin.Context) {
 		attribute.String("/app/api/image/params/via", params.Via),
 		attribute.Int64("/app/api/image/params/max", int64(params.MaxCount)),
 		attribute.Int64("/app/api/image/params/columns", int64(params.Columns)),
+		attribute.Int64("/app/api/image/params/itemSize", int64(params.ItemSize)),
 	)
 	log = log.With(logger.Label("repository", string(params.Repository)))
 	ctx = logger.ContextWithLogger(ctx, log)
@@ -68,6 +69,7 @@ func (api *API) Get(c *gin.Context) {
 	rendererOptions := &renderer.RendererOptions{
 		MaxCount: params.MaxCount,
 		Columns:  params.Columns,
+		ItemSize: params.ItemSize,
 	}
 
 	// get image

--- a/apps/api/internal/api/image/params.go
+++ b/apps/api/internal/api/image/params.go
@@ -12,6 +12,7 @@ type GetImageParams struct {
 	Repository       model.RepositoryString `form:"repo" binding:"required"`
 	MaxCount         int                    `form:"max"`
 	Columns          int                    `form:"columns"`
+	ItemSize         int                    `form:"itemSize"`
 	IncludeAnonymous bool                   `form:"anon"`
 	Preview          bool                   `form:"preview"`
 	Via              string
@@ -22,6 +23,7 @@ func (p GetImageParams) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("repository", string(p.Repository))
 	enc.AddInt("max", p.MaxCount)
 	enc.AddInt("columns", p.Columns)
+	enc.AddInt("itemSize", p.ItemSize)
 	enc.AddBool("anon", p.IncludeAnonymous)
 	enc.AddBool("preview", p.Preview)
 	enc.AddString("via", p.Via)

--- a/apps/api/internal/api/image/params_test.go
+++ b/apps/api/internal/api/image/params_test.go
@@ -15,6 +15,7 @@ func Test_GetImageParams_BindQuery_AllParams(t *testing.T) {
 	q.Set("repo", "angular/angular-ja")
 	q.Set("max", "100")
 	q.Set("columns", "12")
+	q.Set("itemSize", "64")
 	q.Set("anon", "1")
 	q.Set("preview", "1")
 	uri.RawQuery = q.Encode()
@@ -34,6 +35,9 @@ func Test_GetImageParams_BindQuery_AllParams(t *testing.T) {
 		t.Fatalf("Bound params: %v", params)
 	}
 	if params.Columns != 12 {
+		t.Fatalf("Bound params: %v", params)
+	}
+	if params.ItemSize != 64 {
 		t.Fatalf("Bound params: %v", params)
 	}
 	if !params.IncludeAnonymous {

--- a/apps/api/internal/service/image/options.go
+++ b/apps/api/internal/service/image/options.go
@@ -15,6 +15,8 @@ func normalizeRendererOptions(options *renderer.RendererOptions) *renderer.Rende
 	if options.Columns < 1 {
 		options.Columns = defaultColumns
 	}
-	options.ItemSize = defaultItemSize
+	if options.ItemSize < 1 {
+		options.ItemSize = defaultItemSize
+	}
 	return options
 }

--- a/apps/webapp/src/app/pages/preview/image-snippet/image-snippet.component.ts
+++ b/apps/webapp/src/app/pages/preview/image-snippet/image-snippet.component.ts
@@ -18,6 +18,8 @@ import { Repository } from '../../../models/repository';
         <dd style="font-size: 14px; margin-inline-start: 2rem">Max contributor count (100 by default)</dd>
         <dt style="font-family: monospace; font-size: 14px">{{ 'columns={number}' }}</dt>
         <dd style="font-size: 14px; margin-inline-start: 2rem">Max columns (12 by default)</dd>
+        <dt style="font-family: monospace; font-size: 14px">{{ 'itemSize={number}' }}</dt>
+        <dd style="font-size: 14px; margin-inline-start: 2rem">Item size (64 by default)</dd>
         <dt style="font-family: monospace; font-size: 14px">{{ 'anon={0|1}' }}</dt>
         <dd style="font-size: 14px; margin-inline-start: 2rem">Include anonymous users (false by default)</dd>
       </dl>


### PR DESCRIPTION
This PR addresses #18 and implements changing the avatar size. 

The internal code name `itemSize` has been used. Likely something more suitable for the front end should be used such as `avatarSize` as #18 already suggests.