### PR TITLE
docs: add Copilot instructions for contributors

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,43 @@
+# Copilot Instructions
+
+## Warning
+
+- If you find any differences between these instructions and the actual implementation, update these instructions accordingly.
+
+## Language
+
+- Match user's language (Japanese/English/etc.)
+- Default to English if unclear
+
+## Commands
+
+- Build: `npx nx build <project>`
+- Test: `npx nx test <project>`
+- Lint: `npx nx lint <project>`
+- Format: `npx nx format:write`
+
+## Workspace Structure
+
+- `/apps/api` - Go API service (contributor image generation)
+- `/apps/webapp` - Angular frontend application
+- `/apps/worker` - TypeScript background worker
+- `/firebase` - Firebase configuration
+- `/tools` - Build and utility scripts
+
+## Coding Rules
+
+- Go: Follow standard Go idioms and error handling patterns
+- TypeScript: Use strict typing, avoid `any` type
+- Angular: Use standalone components and signals API
+- Tests: Write unit tests for all new functionality
+- Commits: Use conventional commit format
+- Documentation: All code comments and inline documentation must be written in English, regardless of the language used in instructions
+
+## Dependencies Management
+
+- Node.js: Use pnpm for package management
+- Go: Use go modules for dependency management
+- Angular: Follow Angular versioning policy
+- Update dependencies: Run `pnpm update` to update npm packages
+- Go dependencies: Run `go get -u ./...` to update Go modules
+- Security updates: Prioritize security-related dependency updates


### PR DESCRIPTION
Prompts to the agent

```
1. "explain this codebase to me"
2. "I want to add .github/copilot-instructions.md which is a system instruction for you, Copilot. What kind of instructions do you recommend to me?"
3. "It seems too long instruction. clear all lines and add instructions which I order you later."
4. "Add a instruction for chat response language. You should respond to the user in user's language. If user ask you in Japanese, you must speak in Japanese."
5. "Too expressive. Make it short."
6. "Add commands section to explain usual commands which copilot uses like build, test, lint and format."
7. "Test the commands are valid. If no, fix instructions."
8. "add workspace structure seciton"
9. "add coding rules section."
10. "Add heading lile to warn: if you find any differences between following instructions and the actual implementation, update instructions by yourself."
11. "コーディングルールを追加
ソースコード・テストコード中のコメントやインラインドキュメントは常に英語で書くこと。日本語による指示であっても生成されるソースコード中に日本語を混ぜない。"
12. "外部パッケージの依存管理に関するセクションを追加"
```