### PR TITLE
docs: add CLAUDE.md for Claude Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ speed-measure-plugin.json
 *.sublime-workspace
 .firebase
 .credentials
-/.env
+.env
 
 # IDE - VSCode
 .vscode/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,159 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+contrib.rocks — a service that renders a repository's GitHub contributors as a single SVG image, served at
+`GET /image?repo=<owner>/<repo>`. The image is embedded in READMEs, so it is fetched by GitHub's camo proxy far
+more often than by browsers. Caching and cheap responses matter more than request-time freshness.
+
+## Commands
+
+Package manager is **pnpm** (`pnpm@10.8.1`); Node version is pinned in `.node-version`. Nx targets are declared
+in each `apps/*/project.json`.
+
+```bash
+pnpm install                      # required before any nx command
+
+pnpm nx serve api                 # Go API on :3333 (needs GITHUB_AUTH_TOKEN, see below)
+pnpm nx serve webapp              # Angular dev server, proxies /image and /api to :3333
+pnpm nx serve worker              # worker via tsx — also defaults to :3333, so set PORT to run it
+                                  # alongside the API; its one route needs ADC + BigQuery access
+
+pnpm nx test api                  # go test ./... in apps/api
+pnpm nx test golib                # go test ./... from the repo root — covers every Go package
+pnpm nx test webapp               # Karma + ChromeHeadless, single run
+pnpm test:ci                      # all projects
+
+pnpm lint                         # go vet + eslint across projects
+pnpm format                       # gofmt -w + prettier -w
+pnpm build:all:production         # despite the name, builds only webapp
+```
+
+Running a single Go test: `cd apps/api && go test ./internal/service/image/ -run TestName`.
+
+Regenerating the `cupaloy` snapshots under `go/renderer/.snapshots` and `go/dataurl/.snapshots`:
+
+```bash
+UPDATE_SNAPSHOTS=true go test -count=1 ./apps/api/go/...
+```
+
+Do **not** use the `test:u` package script. It expands to a bare `nx test` with no project and exits 1; supplying
+a project makes it worse, because `nx.json` caches the `test` target and `UPDATE_SNAPSHOTS` is not part of the
+hash — Nx replays a cached success without ever starting `go test`, so the snapshots are silently not rewritten.
+`-count=1` defeats Go's own test cache for the same reason.
+
+The `worker` project's `test` and `lint` targets are `echo` stubs — it has no tests and is not linted.
+
+## Local setup for the API
+
+`config.Load` returns an error and the server exits if `GITHUB_AUTH_TOKEN` is unset. `main.go` calls
+`godotenv.Load()` and the `serve` target runs `go run .` with `cwd` = `apps/api`, so put the token in
+`apps/api/.env`. Verify `git check-ignore apps/api/.env` exits 0 before writing a real token into it — this is a
+GitHub credential, and a leaked one has to be revoked, not un-pushed.
+
+Without Google credentials **and** `CACHE_STORAGE_BUCKET`, `NewServicePack` falls back to an in-memory cache
+instead of GCS. That is the normal local configuration.
+
+## Architecture
+
+Three deployables, one Nx workspace:
+
+| Project  | Path           | Stack                        | Deploy target                        |
+| -------- | -------------- | ---------------------------- | ------------------------------------ |
+| `api`    | `apps/api`     | Go 1.23, Gin, OpenTelemetry  | Cloud Run (image built by `ko`)      |
+| `webapp` | `apps/webapp`  | Angular 19 standalone + Material | Firebase Hosting                 |
+| `worker` | `apps/worker`  | Node, Hono, BigQuery→Firestore | Cloud Run (`--source`, buildpacks) |
+
+`apps/api/go/` is a separate Nx project named **`golib`** (tag `lib`), holding `apiclient`, `compress`, `dataurl`,
+`env`, `httptrace`, `model`, `renderer`, `util`. The boundary is Gin and app config — **not** cloud SDKs:
+`go/apiclient` constructs the BigQuery / Firestore / Logging / Storage clients and `go/httptrace` wraps
+OpenTelemetry. A new GCP client belongs in `go/apiclient`, not in `internal/`. `apps/api/internal/` holds what
+knows about Gin, config, and service wiring — `internal/service/services.go` is where GCS-vs-in-memory cache is
+decided. `api` declares `implicitDependencies: ["golib"]`.
+
+One Go module, `contrib.rocks`, rooted at the repo root — not at `apps/api`. Import paths are
+`contrib.rocks/apps/api/...`.
+
+### Request flow for `GET /image`
+
+`internal/api/image` (bind + validate params) → `image.Service.GetImage` (cache lookup; on hit, return) →
+`contributors.Service.GetContributors` (its own cache, then GitHub API) → `image.Service.RenderImage`
+(fetch every avatar, inline as base64 data URL, render SVG, write to cache) → `usage.Service.CollectUsage`.
+
+Every avatar is inlined as a base64 data URL rather than referenced by URL, so the SVG is self-contained. That
+makes rendering expensive — one HTTP request per contributor, parallelised with `errgroup` — which is why the
+cache is load-bearing rather than an optimisation. Keep this in mind before adding work to the render path.
+
+Handlers depend on service *interfaces* declared in the consuming package (`api/image/api.go`), not on the
+concrete service structs. Wiring happens in `internal/service/services.go`.
+
+### Caching
+
+Both layers share one `AppCache` (GCS bucket in deployed environments, in-memory locally). Keys are built only in
+`internal/service/internal/cachekey`:
+
+- contributors JSON — `contributors/v1.2/{owner}--{repo}.json`
+- rendered image — `image/{owner}--{repo}--{anon|noanon}_{max}_{columns}.svg`
+
+**The image key carries no renderer version.** Changing SVG output does not invalidate cached images; the
+contributors key has an explicit `v1.2` for exactly that reason. If you change `go/renderer` output, plan for
+stale entries — responses also carry `cache-control: max-age=259200` (3 days) plus an ETag.
+
+Renderer defaults live in `internal/service/image/options.go` (max 100, 12 columns, 64px items) and are applied by
+`normalizeRendererOptions` before the cache key is computed, so `?max=0` and no `max` hit the same entry.
+
+### webapp ↔ worker coupling
+
+The worker has a single route, `/update-featured-repositories`. It queries the BigQuery table
+`contributors-img.repository_usage.weekly_repository_usage` and writes `featured_repositories` and `usage_stats`
+documents into the Firestore collection named after `APP_ENV`. That table is not defined in this repo; the API
+emits the matching per-request records as structured logs under the `repository-usage` log group
+(`internal/service/usage`), and the pipeline between the two lives in GCP config, not here.
+
+The webapp reads only one of those two documents: `{collection}/featured_repositories`, from the single Firestore
+call site in `app/shared/featured-repository/firestore.ts`. **`usage_stats` has no reader in this repo** — the
+worker writes it and nothing here consumes it, so changing its shape does not break the webapp.
+
+The collection comes from `environment.firestoreRootCollectionName`. All three `src/environments/environment*.ts`
+import the same `firebaseConfig.prod` (`firebase-config.ts` defines no other key), so every environment points at
+the one `contributors-img` Firebase project; they differ in `firestoreRootCollectionName`
+(`development` / `staging` / `production`) and in `production`, which is `false` only in `environment.ts`.
+Environment separation here is by collection, not by project. `firebase/firestore.rules` makes all three
+collections world-readable and client-write-denied.
+
+## Deployment
+
+- Push to `main` → `deploy-staging.yml` deploys all three to staging.
+- `release-please.yml` maintains a release PR; merging it triggers `deploy-production.yml` at the release SHA.
+- `deploy-production.yml` also accepts `workflow_dispatch` with an arbitrary `ref`.
+- Firebase Hosting rewrites `/image` and `/api/**` to the Cloud Run API service, so the webapp and API share an
+  origin in production. Locally, `proxy.conf.json` reproduces this.
+
+Conventional commits are required — release-please derives versions and CHANGELOG from them.
+
+## Conventions
+
+`.github/copilot-instructions.md` also exists, but do not adopt it wholesale. Its coding rules hold (English
+comments, "why" over "what", conventional commits, strict TS). Three things in it do not:
+
+- its Commands section says `npx nx …` — this repo is pnpm, use `pnpm nx`;
+- it offers `nx format:write`, which runs Prettier only and skips the `gofmt -w` in the `api` and `golib` `format`
+  targets. Use `pnpm format`. No CI job checks Go formatting, so unformatted Go can reach `main` uncaught;
+- "write unit tests for all new functionality" does not apply to `worker`, which has no test runner.
+
+Ignore its opening instruction to edit itself when it disagrees with the implementation. Commands are canonical
+here, in this file.
+
+Additionally:
+
+- Comments and identifiers in English. Some existing Go comments are in Japanese; do not add more.
+- Angular: standalone components, `OnPush` (Nx generator default), SCSS. There is no `NgModule` and no
+  `angular.json` — project config lives in `apps/webapp/project.json`. `workspace.json` is **not** the project
+  list: it names only `api`, `webapp`, and `worker`, while `golib` is discovered by Nx from
+  `apps/api/go/project.json`.
+- Tests: Go uses table tests plus `cupaloy` snapshots under `.snapshots/`; webapp uses Karma with
+  `@testing-library/angular`.
+- `.npmrc` sets `shared-workspace-lockfile=false`, so `apps/worker/pnpm-lock.yaml` exists separately. It must stay
+  self-contained — production deploys `--source ./apps/worker` and resolves dependencies there.


### PR DESCRIPTION
## What

Adds a `CLAUDE.md` at the repo root, and fixes the `.env` gitignore anchor that it depends on.

## Why

`CLAUDE.md` is loaded automatically by Claude Code sessions working in this repository, so it is closer to configuration than to prose documentation — what it claims, future sessions act on. It deliberately covers only what is expensive to rediscover by reading source, and skips anything obvious from a directory listing.

The four things it exists to convey:

- The Go module is rooted at the repo root (`contrib.rocks`), not at `apps/api`, and `apps/api/go/` is a separate Nx project (`golib`) that `workspace.json` does not list.
- Two cache layers share one `AppCache`, and their keys are asymmetric: the contributors key carries `v1.2`, the image key carries no renderer version — so changing SVG output does **not** invalidate cached images.
- Every avatar is inlined as a base64 data URL, costing one HTTP request per contributor, which is why the cache is load-bearing rather than an optimisation.
- Environment separation is by Firestore collection name; all three `environment*.ts` point at the same Firebase project.

It also records two traps where a command reports success without doing anything:

- `pnpm test:u` cannot regenerate the `cupaloy` snapshots. It expands to a bare `nx test` and exits 1; supplying a project makes Nx replay a cached success without starting `go test`, because `UPDATE_SNAPSHOTS` is not part of the target's hash. The working command is documented instead.
- `.github/copilot-instructions.md` prescribes `npx nx` (this repo is pnpm) and `nx format:write`, which runs Prettier only and skips the `gofmt -w` in the `api`/`golib` format targets. No CI job checks Go formatting. `CLAUDE.md` now scopes which parts of that file to follow rather than endorsing it wholesale.

## Security fix

`.gitignore` had `/.env`, anchored to the repo root only, so `apps/api/.env` was **not** ignored — and that is exactly where the API's `GITHUB_AUTH_TOKEN` has to live, since the `serve` target runs `go run .` from that directory. Since `CLAUDE.md` instructs contributors to put a real GitHub token there, the anchor is removed so `.env` is ignored at every level. Verified that no currently tracked file becomes ignored by the change.

## Verification

- `pnpm lint` — passes for all 4 projects.
- `pnpm test:ci` — passes for all 4 projects (webapp 18/18).
- `git check-ignore apps/api/.env` now exits 0; `git ls-files | git check-ignore --stdin` returns nothing.
- The documented snapshot command was executed: it runs `go test` for all 8 `golib` packages and leaves the snapshots byte-identical.
- Every factual claim in the file was checked against source. Eight inaccuracies found in review were corrected before this PR was opened.

No runtime code changes, so no release is expected from this PR.
