### PR TITLE
refactor(webapp): replace @angular/fire with plain firebase SDK

### DIFF
--- a/apps/webapp/src/app/app.config.ts
+++ b/apps/webapp/src/app/app.config.ts
@@ -1,24 +1,17 @@
 import { provideHttpClient } from '@angular/common/http';
 import { ApplicationConfig } from '@angular/core';
-import { getAnalytics, provideAnalytics } from '@angular/fire/analytics';
-import { initializeApp, provideFirebaseApp } from '@angular/fire/app';
-import { getFirestore, provideFirestore } from '@angular/fire/firestore';
-import { getPerformance, providePerformance } from '@angular/fire/performance';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
-import { environment } from '../environments/environment';
 import { routes } from './app-routes';
 import { provideFeaturedRepositoryDatasource } from './shared/featured-repository/firestore';
+import { provideFirebase } from './shared/firebase';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideAnimations(),
     provideHttpClient(),
     provideRouter(routes),
-    provideFirebaseApp(() => initializeApp(environment.firebaseConfig)),
-    provideFirestore(() => getFirestore()),
-    provideAnalytics(() => getAnalytics()),
-    providePerformance(() => getPerformance()),
+    provideFirebase(),
     provideFeaturedRepositoryDatasource(),
   ],
 };

--- a/apps/webapp/src/app/shared/featured-repository/firestore.ts
+++ b/apps/webapp/src/app/shared/featured-repository/firestore.ts
@@ -1,8 +1,9 @@
-import { Injectable, Provider, inject } from '@angular/core';
-import { doc, docData, DocumentReference, Firestore } from '@angular/fire/firestore';
+import { Injectable, NgZone, Provider, inject } from '@angular/core';
+import { doc, DocumentReference, onSnapshot } from 'firebase/firestore';
 import { filter, map, Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { FeaturedRepository } from '../../models';
+import { FirestoreToken } from '../firebase';
 import { FeaturedRepositoryDatasource, FeaturedRepositoryDatasourceToken } from './index';
 
 interface FeaturedRepositoryDocument {
@@ -14,14 +15,22 @@ export class FirebaseFeaturedRepositoryDatasource implements FeaturedRepositoryD
   readonly repositories$: Observable<FeaturedRepository[]>;
 
   constructor() {
-    const firestore = inject(Firestore);
+    const firestore = inject(FirestoreToken);
+    const ngZone = inject(NgZone);
 
-    this.repositories$ = docData(
-      doc(
-        firestore,
-        `${environment.firestoreRootCollectionName}/featured_repositories`,
-      ) as DocumentReference<FeaturedRepositoryDocument>,
-    ).pipe(
+    const docRef = doc(
+      firestore,
+      `${environment.firestoreRootCollectionName}/featured_repositories`,
+    ) as DocumentReference<FeaturedRepositoryDocument>;
+
+    this.repositories$ = new Observable<FeaturedRepositoryDocument | undefined>((subscriber) => {
+      const unsubscribe = onSnapshot(
+        docRef,
+        (snapshot) => ngZone.run(() => subscriber.next(snapshot.data())),
+        (error) => ngZone.run(() => subscriber.error(error)),
+      );
+      return unsubscribe;
+    }).pipe(
       filter((doc): doc is FeaturedRepositoryDocument => doc != null),
       map((doc) => doc.items),
     );

--- a/apps/webapp/src/app/shared/featured-repository/firestore.ts
+++ b/apps/webapp/src/app/shared/featured-repository/firestore.ts
@@ -23,14 +23,19 @@ export class FirebaseFeaturedRepositoryDatasource implements FeaturedRepositoryD
       `${environment.firestoreRootCollectionName}/featured_repositories`,
     ) as DocumentReference<FeaturedRepositoryDocument>;
 
-    this.repositories$ = new Observable<FeaturedRepositoryDocument | undefined>((subscriber) => {
-      const unsubscribe = onSnapshot(
-        docRef,
-        (snapshot) => ngZone.run(() => subscriber.next(snapshot.data())),
-        (error) => ngZone.run(() => subscriber.error(error)),
-      );
-      return unsubscribe;
-    }).pipe(
+    // The listener is registered outside the Angular zone: zone.js patches the transport,
+    // so a listener opened inside the zone would make every long-poll keep-alive and retry
+    // timer schedule a change-detection pass for the life of the page. Only actual snapshot
+    // deliveries re-enter the zone, via the `run` calls below.
+    this.repositories$ = new Observable<FeaturedRepositoryDocument | undefined>((subscriber) =>
+      ngZone.runOutsideAngular(() =>
+        onSnapshot(
+          docRef,
+          (snapshot) => ngZone.run(() => subscriber.next(snapshot.data())),
+          (error) => ngZone.run(() => subscriber.error(error)),
+        ),
+      ),
+    ).pipe(
       filter((doc): doc is FeaturedRepositoryDocument => doc != null),
       map((doc) => doc.items),
     );

--- a/apps/webapp/src/app/shared/firebase.ts
+++ b/apps/webapp/src/app/shared/firebase.ts
@@ -1,17 +1,17 @@
 import { InjectionToken, Provider } from '@angular/core';
 import { FirebaseApp, initializeApp } from 'firebase/app';
-import { getAnalytics } from 'firebase/analytics';
 import { Firestore, getFirestore } from 'firebase/firestore';
-import { getPerformance } from 'firebase/performance';
 import { environment } from '../../environments/environment';
 
 export const FirestoreToken = new InjectionToken<Firestore>('Firestore');
 
+// Analytics and Performance are deliberately not started here. `provideAnalytics` /
+// `providePerformance` only registered lazy factories, and nothing ever injected those
+// tokens, so neither service was running before this migration. Starting them would be a
+// behaviour change — and an unguarded one, since every environment file resolves to the
+// production Firebase config.
 export function provideFirebase(): Provider[] {
   const app: FirebaseApp = initializeApp(environment.firebaseConfig);
-  // Not consumed directly; initializing them registers auto-instrumentation.
-  getAnalytics(app);
-  getPerformance(app);
 
   return [{ provide: FirestoreToken, useValue: getFirestore(app) }];
 }

--- a/apps/webapp/src/app/shared/firebase.ts
+++ b/apps/webapp/src/app/shared/firebase.ts
@@ -1,0 +1,17 @@
+import { InjectionToken, Provider } from '@angular/core';
+import { FirebaseApp, initializeApp } from 'firebase/app';
+import { getAnalytics } from 'firebase/analytics';
+import { Firestore, getFirestore } from 'firebase/firestore';
+import { getPerformance } from 'firebase/performance';
+import { environment } from '../../environments/environment';
+
+export const FirestoreToken = new InjectionToken<Firestore>('Firestore');
+
+export function provideFirebase(): Provider[] {
+  const app: FirebaseApp = initializeApp(environment.firebaseConfig);
+  // Not consumed directly; initializing them registers auto-instrumentation.
+  getAnalytics(app);
+  getPerformance(app);
+
+  return [{ provide: FirestoreToken, useValue: getFirestore(app) }];
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@angular/common": "19.2.2",
     "@angular/compiler": "19.2.2",
     "@angular/core": "19.2.2",
-    "@angular/fire": "19.0.0",
     "@angular/forms": "19.2.2",
     "@angular/material": "18.2.14",
     "@angular/platform-browser": "19.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@angular/core':
         specifier: 19.2.2
         version: 19.2.2(rxjs@7.8.2)(zone.js@0.14.8)
-      '@angular/fire':
-        specifier: 19.0.0
-        version: 19.0.0(@angular/common@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(@angular/platform-browser-dynamic@19.2.2(@angular/common@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(@angular/compiler@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(@angular/platform-browser@19.2.2(@angular/animations@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))(@angular/common@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))))(@angular/platform-browser@19.2.2(@angular/animations@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))(@angular/common@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))(chokidar@4.0.3)(firebase-tools@14.2.0(encoding@0.1.13))(rxjs@7.8.2)
       '@angular/forms':
         specifier: 19.2.2
         version: 19.2.2(@angular/common@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(@angular/platform-browser@19.2.2(@angular/animations@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))(@angular/common@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))(rxjs@7.8.2)
@@ -321,22 +318,6 @@ packages:
     peerDependencies:
       rxjs: ^6.5.3 || ^7.4.0
       zone.js: ~0.15.0
-
-  '@angular/fire@19.0.0':
-    resolution: {integrity: sha512-dVU9IdL9sGKe1fV7g2iGgkjUQIYrbnljHtHUgNpZaskyW+Vy6ndtsEbSUoRd6sLP8WpThWH7WvITKhu/8a6qfQ==}
-    peerDependencies:
-      '@angular/common': ^19.0.0
-      '@angular/core': ^19.0.0
-      '@angular/platform-browser': ^19.0.0
-      '@angular/platform-browser-dynamic': ^19.0.0
-      '@angular/platform-server': ^19.0.0
-      firebase-tools: ^13.0.0
-      rxjs: ~7.8.0
-    peerDependenciesMeta:
-      '@angular/platform-server':
-        optional: true
-      firebase-tools:
-        optional: true
 
   '@angular/forms@19.2.2':
     resolution: {integrity: sha512-Cin+VdP4SbSZU1VQvZLkIJ6j0srGoWHG/yS7HjsVRNGQHT9kRGi/sz8DE0wHYspLPkq0dGgkVFUcjzDKs3O+wA==}
@@ -5716,12 +5697,6 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  rxfire@6.1.0:
-    resolution: {integrity: sha512-NezdjeY32VZcCuGO0bbb8H8seBsJSCaWdUwGsHNzUcAOHR0VGpzgPtzjuuLXr8R/iemkqSzbx/ioS7VwV43ynA==}
-    peerDependencies:
-      firebase: ^9.0.0 || ^10.0.0 || ^11.0.0
-      rxjs: ^6.0.0 || ^7.0.0
-
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
 
@@ -6966,24 +6941,6 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
       zone.js: 0.14.8
-
-  '@angular/fire@19.0.0(@angular/common@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(@angular/platform-browser-dynamic@19.2.2(@angular/common@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(@angular/compiler@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(@angular/platform-browser@19.2.2(@angular/animations@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))(@angular/common@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))))(@angular/platform-browser@19.2.2(@angular/animations@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))(@angular/common@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))(chokidar@4.0.3)(firebase-tools@14.2.0(encoding@0.1.13))(rxjs@7.8.2)':
-    dependencies:
-      '@angular-devkit/schematics': 19.2.15(chokidar@4.0.3)
-      '@angular/common': 19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2)
-      '@angular/core': 19.2.2(rxjs@7.8.2)(zone.js@0.14.8)
-      '@angular/platform-browser': 19.2.2(@angular/animations@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))(@angular/common@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))
-      '@angular/platform-browser-dynamic': 19.2.2(@angular/common@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(@angular/compiler@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(@angular/platform-browser@19.2.2(@angular/animations@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))(@angular/common@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))
-      '@schematics/angular': 19.2.15(chokidar@4.0.3)
-      firebase: 11.6.0
-      rxfire: 6.1.0(firebase@11.6.0)(rxjs@7.8.2)
-      rxjs: 7.8.2
-      tslib: 2.8.1
-    optionalDependencies:
-      firebase-tools: 14.2.0(encoding@0.1.13)
-    transitivePeerDependencies:
-      - '@react-native-async-storage/async-storage'
-      - chokidar
 
   '@angular/forms@19.2.2(@angular/common@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(@angular/platform-browser@19.2.2(@angular/animations@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))(@angular/common@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))(rxjs@7.8.2)':
     dependencies:
@@ -13150,11 +13107,6 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
-
-  rxfire@6.1.0(firebase@11.6.0)(rxjs@7.8.2):
-    dependencies:
-      firebase: 11.6.0
-      rxjs: 7.8.2
 
   rxjs@7.8.1:
     dependencies:


### PR DESCRIPTION
Removes `@angular/fire@19.0.0` and talks to the plain `firebase` JS SDK directly.

## Why

`@angular/fire` is a thin wrapper that tracks Angular majors, and its peer (`@angular/core ^20.0.0`) is what caps this app at Angular 20. The plain SDK has no Angular dependency, so removing the wrapper removes the ceiling. This is a prerequisite for the Angular 19→22 upgrade, not a goal in itself.

`firebase` 11.6.0 was already a direct dependency — nothing new is installed.

## What changed

- `shared/firebase.ts` (new) — `provideFirebase()` calls `initializeApp()` and registers `getFirestore(app)` through a `FirestoreToken: InjectionToken<Firestore>`.
- `app.config.ts` — the four `@angular/fire` provider calls collapse into one `provideFirebase()`.
- `featured-repository/firestore.ts` — `docData()` becomes `new Observable()` around `onSnapshot`, registered outside the Angular zone, with the unsubscribe function `onSnapshot` returns as the teardown.

The consumer and its spec are untouched: they only depend on the `FeaturedRepositoryDatasourceToken` abstract class, and the spec uses `noop.ts`.

## Two things review caught that the first pass got wrong

**Analytics and Performance were never running.** The first pass carried `getAnalytics()` / `getPerformance()` across on the assumption that they were active and had to stay active. They were not. `provideAnalytics(() => getAnalytics())` registers a lazy factory, and `git grep` over `main` finds no injection of `Analytics` or `Performance` anywhere in `apps/webapp/src` — so those factories never ran. Calling the functions directly would have started both services for the first time, and unguarded: all three `src/environments/environment*.ts` import the same `firebaseConfig.prod`, so `pnpm nx serve webapp` and every staging deploy would have written into the production GA property and Performance dashboard. Both calls are dropped, which is what preserving `main`'s behaviour actually means. Turning telemetry on is a separate, environment-gated change.

**The zone contract was half-applied.** `onSnapshot` was being registered from inside the subscriber function, which runs at subscribe time — inside the `async` pipe, inside the Angular zone. zone.js patches the transport, so the WebChannel long-poll, its retry timers and the persistence layer all inherited the Angular zone and drove an `ApplicationRef.tick()` for the life of the page; the `NgZone.run()` wrappers around the callbacks were no-ops, because the callbacks were already in the zone. Registration now happens in `ngZone.runOutsideAngular()`, so only real snapshot deliveries re-enter — which is what `@angular/fire`'s `ɵzoneWrap` did. This matters beyond the tick cost: the 19→22 upgrade should start from zone parity, not from a regression.

## Bundle size, measured

All three rebuilt with `--skip-nx-cache`:

| | Raw | Transfer |
| --- | --- | --- |
| `main` | 1.04 MB | 242.88 kB |
| first pass | 979.26 kB | 227.09 kB |
| this branch | 933.92 kB | **214.48 kB** |

−28.40 kB transfer against `main`, −11.7%. The `main` chunk itself goes 203.87 → 194.10 kB: the Analytics and Performance SDKs were being bundled all along even though nothing ever executed them, and dropping the imports tree-shakes them out. `chunk-25EI6UN2` (18.63 kB transfer) also disappears — it was an **initial** chunk, not lazy; the only lazy chunk was `index-esm` at 121 bytes.

## Verification

- `grep -rn "@angular/fire" apps/webapp/src` — no hits; gone from `package.json`; lockfile −48 lines.
- `pnpm exec tsc -p apps/webapp/tsconfig.app.json --noEmit` — exits 0.
- `pnpm nx test webapp` — 18/18.
- `pnpm nx lint webapp` — clean.
- `pnpm build:all:production` — succeeds.
- Peer warnings lose the `firebase-tools@^13.0.0` line. The remaining two (`zone.js@~0.15.0` vs 0.14.8, `eslint-config-prettier@^9` vs 8.10.0) are pre-existing and unrelated.

Neither of the two defects above is caught by any of these — the spec suite exercises `noop.ts`, so the Firestore path has no test coverage at all.

## Not yet verified

The live path. `Used by` rendering, and a Firestore update actually reaching the screen — the real proof that the zone handling is right — needs a deployment with the Cloud Run rewrites in front of it. The Cloudflare Pages preview cannot show it: it has no rewrite for `/image` or `/api/**`, so those paths fall through to `index.html` there, on this branch and on `main` alike.
