### PR TITLE
refactor(webapp): replace @rx-angular/state with a signal store

### DIFF
--- a/apps/webapp/src/app/pages/preview/image-preview/image-preview.component.ts
+++ b/apps/webapp/src/app/pages/preview/image-preview/image-preview.component.ts
@@ -1,6 +1,4 @@
-import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { map } from 'rxjs';
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { ImagePreviewFormComponent } from '../image-preview-form/image-preview-form.component';
 import { ImagePreviewResultComponent } from '../image-preview-result/image-preview-result.component';
 import { PreviewState } from '../state';
@@ -8,7 +6,7 @@ import { PreviewState } from '../state';
 @Component({
   selector: 'app-image-preview',
   template: `
-    @if (state$ | async; as state) {
+    @if (viewModel(); as state) {
       <app-image-preview-form [value]="state.imageParams" />
       @if (state.loading) {
         <img height="100" src="assets/images/loading.gif" alt="Loading..." />
@@ -23,16 +21,17 @@ import { PreviewState } from '../state';
   `,
   styleUrls: ['./image-preview.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, ImagePreviewFormComponent, ImagePreviewResultComponent],
+  imports: [ImagePreviewFormComponent, ImagePreviewResultComponent],
 })
 export class ImagePreviewComponent {
-  private readonly state = inject(PreviewState);
+  private readonly store = inject(PreviewState);
 
-  readonly state$ = this.state.select().pipe(
-    map((state) => ({
+  readonly viewModel = computed(() => {
+    const state = this.store.state();
+    return {
       imageParams: state.imageParams,
       loading: state.fetchingCount > 0,
       result: state.result,
-    })),
-  );
+    };
+  });
 }

--- a/apps/webapp/src/app/pages/preview/preview.component.ts
+++ b/apps/webapp/src/app/pages/preview/preview.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject, OnDestroy, OnInit } from '@angular/core';
+import { Component, computed, inject, OnDestroy, OnInit } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { delay, firstValueFrom, Subject, takeUntil } from 'rxjs';
 import { ImageParams } from '../../models/image-params';
@@ -31,10 +32,11 @@ interface PreviewPageParams {
 })
 export class PreviewPageComponent implements OnInit, OnDestroy {
   private readonly onDestroy$ = new Subject<void>();
-  private readonly state = inject(PreviewState);
+  private readonly store = inject(PreviewState);
   private readonly router = inject(Router);
   private readonly imageApi = inject(ContributorsImageApi);
   private readonly queryParams$ = inject(ActivatedRoute).queryParams.pipe(takeUntil(this.onDestroy$));
+  private readonly imageParams$ = toObservable(computed(() => this.store.state().imageParams));
 
   ngOnInit() {
     this.updateStateOnQueryParamsChange();
@@ -48,7 +50,7 @@ export class PreviewPageComponent implements OnInit, OnDestroy {
   private updateStateOnQueryParamsChange() {
     this.queryParams$.subscribe((params) => {
       const { repo = null, max = null, columns = null } = params;
-      this.state.patchImageParams({
+      this.store.patchImageParams({
         repository: repo ? Repository.fromString(repo) : defaultImageParams.repository,
         max: Number(max) || defaultImageParams.max,
         columns: Number(columns) || defaultImageParams.columns,
@@ -57,20 +59,17 @@ export class PreviewPageComponent implements OnInit, OnDestroy {
   }
 
   private refreshOnStateChange() {
-    this.state
-      .select('imageParams')
-      .pipe(takeUntil(this.onDestroy$))
-      .subscribe(async (imageParams) => {
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-        this.updateQueryParams(imageParams);
-        try {
-          this.state.startFetchingImage();
-          const image = await firstValueFrom(this.imageApi.getImage(imageParams).pipe(delay(100)));
-          this.state.finishFetchingImage({ data: image });
-        } catch {
-          this.state.finishFetchingImage(null);
-        }
-      });
+    this.imageParams$.pipe(takeUntil(this.onDestroy$)).subscribe(async (imageParams) => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      this.updateQueryParams(imageParams);
+      try {
+        this.store.startFetchingImage();
+        const image = await firstValueFrom(this.imageApi.getImage(imageParams).pipe(delay(100)));
+        this.store.finishFetchingImage({ data: image });
+      } catch {
+        this.store.finishFetchingImage(null);
+      }
+    });
   }
 
   private async updateQueryParams(params: ImageParams) {

--- a/apps/webapp/src/app/pages/preview/state.spec.ts
+++ b/apps/webapp/src/app/pages/preview/state.spec.ts
@@ -32,11 +32,7 @@ describe('PreviewState', () => {
 
   describe('finishFetchingContributors()', () => {
     it('should update value', () => {
-      state.set((state) => ({
-        ...state,
-        fetchingCount: 1,
-        result: null,
-      }));
+      state.startFetchingImage();
 
       state.finishFetchingImage(null);
 

--- a/apps/webapp/src/app/pages/preview/state.spec.ts
+++ b/apps/webapp/src/app/pages/preview/state.spec.ts
@@ -15,18 +15,18 @@ describe('PreviewState', () => {
   });
 
   it('should has initial value', () => {
-    expect(state.get()).toBeDefined();
-    expect(state.get().imageParams).toBe(defaultImageParams);
-    expect(state.get().result).toEqual(null);
-    expect(state.get().fetchingCount).toEqual(0);
+    expect(state.state()).toBeDefined();
+    expect(state.state().imageParams).toBe(defaultImageParams);
+    expect(state.state().result).toEqual(null);
+    expect(state.state().fetchingCount).toEqual(0);
   });
 
   describe('startFetchingContributors()', () => {
     it('should update value', () => {
       state.startFetchingImage();
 
-      expect(state.get().result).toEqual(null);
-      expect(state.get().fetchingCount).toEqual(1);
+      expect(state.state().result).toEqual(null);
+      expect(state.state().fetchingCount).toEqual(1);
     });
   });
 
@@ -36,7 +36,7 @@ describe('PreviewState', () => {
 
       state.finishFetchingImage(null);
 
-      expect(state.get().fetchingCount).toEqual(0);
+      expect(state.state().fetchingCount).toEqual(0);
     });
   });
 });

--- a/apps/webapp/src/app/pages/preview/state.ts
+++ b/apps/webapp/src/app/pages/preview/state.ts
@@ -27,10 +27,6 @@ export class PreviewState {
   readonly #state = signal<State>(initialValue);
   readonly state = this.#state.asReadonly();
 
-  get(): State {
-    return this.#state();
-  }
-
   startFetchingImage() {
     this.#state.update((state) => ({
       ...state,

--- a/apps/webapp/src/app/pages/preview/state.ts
+++ b/apps/webapp/src/app/pages/preview/state.ts
@@ -1,5 +1,4 @@
-import { Injectable } from '@angular/core';
-import { RxState } from '@rx-angular/state';
+import { Injectable, signal } from '@angular/core';
 import { ImageParams } from '../../models/image-params';
 import { Repository } from '../../models/repository';
 
@@ -24,14 +23,16 @@ export const initialValue: State = {
 };
 
 @Injectable()
-export class PreviewState extends RxState<State> {
-  constructor() {
-    super();
-    this.set(initialValue);
+export class PreviewState {
+  readonly #state = signal<State>(initialValue);
+  readonly state = this.#state.asReadonly();
+
+  get(): State {
+    return this.#state();
   }
 
   startFetchingImage() {
-    this.set((state) => ({
+    this.#state.update((state) => ({
       ...state,
       fetchingCount: state.fetchingCount + 1,
       result: null,
@@ -39,7 +40,7 @@ export class PreviewState extends RxState<State> {
   }
 
   finishFetchingImage(result: { data: string } | null) {
-    this.set((state) => ({
+    this.#state.update((state) => ({
       ...state,
       fetchingCount: state.fetchingCount - 1,
       result,
@@ -47,7 +48,7 @@ export class PreviewState extends RxState<State> {
   }
 
   patchImageParams(params: Partial<ImageParams>) {
-    this.set((state) => ({
+    this.#state.update((state) => ({
       ...state,
       imageParams: {
         ...state.imageParams,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@angular/platform-browser": "19.2.2",
     "@angular/platform-browser-dynamic": "19.2.2",
     "@angular/router": "19.2.2",
-    "@rx-angular/state": "19.0.3",
     "firebase": "11.6.0",
     "normalize.css": "8.0.1",
     "rxjs": "7.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       '@angular/router':
         specifier: 19.2.2
         version: 19.2.2(@angular/common@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(@angular/platform-browser@19.2.2(@angular/animations@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))(@angular/common@19.2.2(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8)))(rxjs@7.8.2)
-      '@rx-angular/state':
-        specifier: 19.0.3
-        version: 19.0.3(@angular-devkit/core@19.2.15(chokidar@4.0.3))(@angular-devkit/schematics@19.2.15(chokidar@4.0.3))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(@rx-angular/cdk@19.1.0(@angular-devkit/core@19.2.15(chokidar@4.0.3))(@angular-devkit/schematics@19.2.15(chokidar@4.0.3))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(rxjs@7.8.2)
       firebase:
         specifier: 11.6.0
         version: 11.6.0
@@ -2302,19 +2299,6 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
-  '@rx-angular/cdk@19.1.0':
-    resolution: {integrity: sha512-4Q6AZebAakLKLZkgntAWLyV02Hwu9pqSE7wL5sgflW8mS63kUXi3YrGuFjdxjJA2oHGj4LTNGOhB0udy+X58gA==}
-    peerDependencies:
-      '@angular/core': ^19.0.0
-      rxjs: ^6.5.3 || ^7.4.0
-
-  '@rx-angular/state@19.0.3':
-    resolution: {integrity: sha512-INYUKH7xic+QvVinx5bQZOSNgBbQ1sV+Sxy2iM99WnsjF4jE+O10ddZv/Qydrw3dIEQ4qXBrW2bkp+ZLBYkzXQ==}
-    peerDependencies:
-      '@angular/core': ^19.0.0
-      '@rx-angular/cdk': ^19.1.0
-      rxjs: ^6.5.3 || ^7.4.0
-
   '@schematics/angular@19.2.15':
     resolution: {integrity: sha512-dz/eoFQKG09POSygpEDdlCehFIMo35HUM2rVV8lx9PfQEibpbGwl1NNQYEbqwVjTyCyD/ILyIXCWPE+EfTnG4g==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
@@ -2462,9 +2446,6 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
-  '@ts-morph/common@0.24.0':
-    resolution: {integrity: sha512-c1xMmNHWpNselmpIqursHeOHHBTIsJLbB+NuovbTTRCNiTLEr/U9dbJ8qy0jd/O2x5pc3seWuOUN5R2IoOTp8A==}
-
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
 
@@ -2511,9 +2492,6 @@ packages:
 
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
-
-  '@types/minimatch@3.0.5':
-    resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
 
   '@types/node@22.15.33':
     resolution: {integrity: sha512-wzoocdnnpSxZ+6CjW4ADCK1jVmd1S/J3ArNWfn8FDDQtRm8dkDg7TA+mvek2wNrfCgwuZxqEOiB9B1XCJ6+dbw==}
@@ -2743,20 +2721,12 @@ packages:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
 
-  array-differ@3.0.0:
-    resolution: {integrity: sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==}
-    engines: {node: '>=8'}
-
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
   array-includes@3.1.8:
     resolution: {integrity: sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==}
     engines: {node: '>= 0.4'}
-
-  array-union@2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
-    engines: {node: '>=8'}
 
   array.prototype.findlastindex@1.2.6:
     resolution: {integrity: sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==}
@@ -3059,9 +3029,6 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
-
-  code-block-writer@13.0.3:
-    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -4858,10 +4825,6 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
-  minimatch@10.0.1:
-    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
-    engines: {node: 20 || >=22}
-
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -4969,10 +4932,6 @@ packages:
   msgpackr@1.11.4:
     resolution: {integrity: sha512-uaff7RG9VIC4jacFW9xzL3jc0iM32DNHe4jYVycBcjUePT/Klnfj7pqtWJt9khvDFizmjN2TlYniYmSS2LIaZg==}
 
-  multimatch@5.0.0:
-    resolution: {integrity: sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==}
-    engines: {node: '>=10'}
-
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
@@ -5022,13 +4981,6 @@ packages:
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
-
-  ng-morph@4.8.4:
-    resolution: {integrity: sha512-XwL53wCOhyaAxvoekN74ONbWUK30huzp+GpZYyC01RfaG2AX9l7YlC1mGG/l7Rx7YXtFAk85VFnNJqn2e46K8g==}
-    peerDependencies:
-      '@angular-devkit/core': '>=16.0.0'
-      '@angular-devkit/schematics': '>=16.0.0'
-      tslib: ^2.7.0
 
   node-addon-api@6.1.0:
     resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
@@ -5306,9 +5258,6 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
-
-  path-browserify@1.0.1:
-    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -6253,9 +6202,6 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
-
-  ts-morph@23.0.0:
-    resolution: {integrity: sha512-FcvFx7a9E8TUe6T3ShihXJLiJOiqyafzFKUO4aqIHDUCIvADdGNShcbc2W5PMr3LerXRv7mafvFZ9lRENxJmug==}
 
   ts-node@10.9.1:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
@@ -9064,27 +9010,6 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
-  '@rx-angular/cdk@19.1.0(@angular-devkit/core@19.2.15(chokidar@4.0.3))(@angular-devkit/schematics@19.2.15(chokidar@4.0.3))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2)':
-    dependencies:
-      '@angular/core': 19.2.2(rxjs@7.8.2)(zone.js@0.14.8)
-      ng-morph: 4.8.4(@angular-devkit/core@19.2.15(chokidar@4.0.3))(@angular-devkit/schematics@19.2.15(chokidar@4.0.3))(tslib@2.8.1)
-      rxjs: 7.8.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@angular-devkit/core'
-      - '@angular-devkit/schematics'
-
-  '@rx-angular/state@19.0.3(@angular-devkit/core@19.2.15(chokidar@4.0.3))(@angular-devkit/schematics@19.2.15(chokidar@4.0.3))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(@rx-angular/cdk@19.1.0(@angular-devkit/core@19.2.15(chokidar@4.0.3))(@angular-devkit/schematics@19.2.15(chokidar@4.0.3))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2))(rxjs@7.8.2)':
-    dependencies:
-      '@angular/core': 19.2.2(rxjs@7.8.2)(zone.js@0.14.8)
-      '@rx-angular/cdk': 19.1.0(@angular-devkit/core@19.2.15(chokidar@4.0.3))(@angular-devkit/schematics@19.2.15(chokidar@4.0.3))(@angular/core@19.2.2(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2)
-      ng-morph: 4.8.4(@angular-devkit/core@19.2.15(chokidar@4.0.3))(@angular-devkit/schematics@19.2.15(chokidar@4.0.3))(tslib@2.8.1)
-      rxjs: 7.8.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@angular-devkit/core'
-      - '@angular-devkit/schematics'
-
   '@schematics/angular@19.2.15(chokidar@4.0.3)':
     dependencies:
       '@angular-devkit/core': 19.2.15(chokidar@4.0.3)
@@ -9222,13 +9147,6 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
-  '@ts-morph/common@0.24.0':
-    dependencies:
-      fast-glob: 3.3.3
-      minimatch: 9.0.5
-      mkdirp: 3.0.1
-      path-browserify: 1.0.1
-
   '@tsconfig/node10@1.0.11': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -9265,8 +9183,6 @@ snapshots:
   '@types/json5@0.0.29': {}
 
   '@types/long@4.0.2': {}
-
-  '@types/minimatch@3.0.5': {}
 
   '@types/node@22.15.33':
     dependencies:
@@ -9531,8 +9447,6 @@ snapshots:
       call-bound: 1.0.4
       is-array-buffer: 3.0.5
 
-  array-differ@3.0.0: {}
-
   array-flatten@1.1.1: {}
 
   array-includes@3.1.8:
@@ -9543,8 +9457,6 @@ snapshots:
       es-object-atoms: 1.1.1
       get-intrinsic: 1.3.0
       is-string: 1.1.1
-
-  array-union@2.1.0: {}
 
   array.prototype.findlastindex@1.2.6:
     dependencies:
@@ -9916,8 +9828,6 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clone@1.0.4: {}
-
-  code-block-writer@13.0.3: {}
 
   color-convert@1.9.3:
     dependencies:
@@ -12109,10 +12019,6 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  minimatch@10.0.1:
-    dependencies:
-      brace-expansion: 2.0.1
-
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -12231,14 +12137,6 @@ snapshots:
       msgpackr-extract: 3.0.3
     optional: true
 
-  multimatch@5.0.0:
-    dependencies:
-      '@types/minimatch': 3.0.5
-      array-differ: 3.0.0
-      array-union: 2.1.0
-      arrify: 2.0.1
-      minimatch: 3.1.2
-
   mute-stream@0.0.8: {}
 
   mute-stream@1.0.0: {}
@@ -12278,16 +12176,6 @@ snapshots:
   negotiator@1.0.0: {}
 
   netmask@2.0.2: {}
-
-  ng-morph@4.8.4(@angular-devkit/core@19.2.15(chokidar@4.0.3))(@angular-devkit/schematics@19.2.15(chokidar@4.0.3))(tslib@2.8.1):
-    dependencies:
-      '@angular-devkit/core': 19.2.15(chokidar@4.0.3)
-      '@angular-devkit/schematics': 19.2.15(chokidar@4.0.3)
-      jsonc-parser: 3.3.1
-      minimatch: 10.0.1
-      multimatch: 5.0.0
-      ts-morph: 23.0.0
-      tslib: 2.8.1
 
   node-addon-api@6.1.0:
     optional: true
@@ -12690,8 +12578,6 @@ snapshots:
       entities: 6.0.1
 
   parseurl@1.3.3: {}
-
-  path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
 
@@ -13761,11 +13647,6 @@ snapshots:
   ts-api-utils@2.0.1(typescript@5.5.4):
     dependencies:
       typescript: 5.5.4
-
-  ts-morph@23.0.0:
-    dependencies:
-      '@ts-morph/common': 0.24.0
-      code-block-writer: 13.0.3
 
   ts-node@10.9.1(@types/node@22.15.33)(typescript@5.5.4):
     dependencies:


### PR DESCRIPTION
Removes `@rx-angular/state@19.0.3` and replaces `PreviewState` with a plain signal store.

## Why

`@rx-angular/state` tracks Angular majors, and **no Angular 22 build exists** — the newest release is 21.1.2, peer `@angular/core ^21.0.0`, and `latest` points there. With `@angular/fire` gone, this was the last package pinning the app's Angular ceiling. Removing it means no third-party package has to be dragged along by the 19→22 upgrade.

The library was barely used: `set`, `get` and `select` on a three-field state. `connect`, `hold` and the rest of what makes RxState worth having were never touched.

## What changed

- `state.ts` — `PreviewState` no longer extends `RxState<State>`. It holds `signal<State>` behind a private field and exposes `readonly state` via `asReadonly()`. `startFetchingImage()`, `finishFetchingImage()` and `patchImageParams()` keep identical semantics through `signal.update()`. `State`, `defaultImageParams` and `initialValue` are unchanged, and the store stays component-scoped on `PreviewPageComponent`.
- `image-preview.component.ts` — renders only, so `select().pipe(map(...)) | async` becomes a `computed()` view model. `CommonModule` and the `map` import drop out with the `async` pipe.
- `preview.component.ts` — stays stream-based, bridged with `toObservable(computed(() => store.state().imageParams))`. Its subscriber does scroll, router navigation, an HTTP fetch and then writes back into the same store; that write-back is exactly what should not live in an `effect()`.
- `state.spec.ts` — reads through `state.state()`. The one place that used RxState's generic `set()` as test scaffolding now calls `startFetchingImage()`, which produces the identical precondition through the public API.

The injected field is named `store` in both components, because `state.state()` reads badly once the signal itself is called `state`.

## The trap this had to avoid

`preview.component.ts` previously subscribed to `select('imageParams')`, whose **distinct** emission is load-bearing: the subscriber fetches an image and then calls `startFetchingImage()` / `finishFetchingImage()`, which change `fetchingCount` and `result` while leaving the `imageParams` object reference alone. Anything emitting on every state change turns that into fetch → set → emit → fetch.

`computed` dedupes with `Object.is`, and RxState's keyed `select` dedupes with `distinctUntilChanged`'s default reference comparison — the same rule. That was verified rather than assumed: the subscriber was instrumented with a counter and driven in a real browser. A fresh load of `/preview?repo=…` emits twice (once for the initial value, once because the query-param patch builds a new `Repository` instance), then stays put across the fetch's state writes; submitting the form emits exactly once more. The counts match `main` — the feedback path through `router.navigate` terminates in both, because the router compares serialized query strings and skips a same-URL navigation.

Review also confirmed the emissions are not merely equal in count but equal in timing: `toObservable` in a field initializer creates a *view* effect, not a root effect, so it runs inside the same change-detection pass rather than a later microtask.

## Verification

- `grep -rn "@rx-angular" apps/webapp/src package.json pnpm-lock.yaml` — no hits. `@rx-angular/cdk` goes too, as its only dependent.
- `pnpm exec tsc -p apps/webapp/tsconfig.app.json --noEmit` — exits 0.
- `pnpm nx test webapp --skip-nx-cache` — 18/18, same as before.
- `pnpm nx lint webapp --skip-nx-cache` — clean.
- `pnpm build:all:production --skip-nx-cache` — succeeds. Initial total 933.92 kB / 214.48 kB transfer on `main` → **925.86 kB / 212.35 kB** here.

## Not yet verified

Behaviour on a deployed environment: that changing the repository, `max` and `columns` still drives image generation. The Cloudflare Pages preview cannot show it — it has no rewrite for `/image` or `/api/**`, so those fall through to `index.html` there, on this branch and on `main` alike.

## Deliberately untouched

Several pre-existing rough edges in these files are identical on `main` and are left alone: the swallowed error in `refreshOnStateChange`'s `catch`, the floating promise from `updateQueryParams`, `finishFetchingImage` decrementing without a floor, and `Number(max) || default` treating `?max=0` as absent.
