### PR TITLE
fix(deps): close two gaps in the nx update suppression

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,13 @@
   "packageRules": [
     {
       "description": "Disable nx package updates except for patch. Nx major/minor bumps need `nx migrate` to run migration scripts, which Renovate cannot do; a plain version bump would leave the workspace config stale.",
-      "matchPackageNames": ["@nrwl/*", "@nx/*"],
+      "matchPackageNames": ["@nrwl/*", "@nx/*", "nx"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
+      "description": "Disable angular-eslint major/minor updates for the same reason as nx above. It is published from github.com/angular-eslint/angular-eslint, not angular/angular, so the shared ng-update preset's source-prefix match does not cover it.",
+      "matchPackageNames": ["angular-eslint", "@angular-eslint/*"],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     },


### PR DESCRIPTION
The `packageRules` entry that disables major and minor updates for Nx packages exists for a good reason: Renovate can only rewrite version strings, while `nx migrate` is what runs the migration scripts. A plain bump leaves workspace config stale. Its own `description` says so.

Two packages that need that protection are not matched by it.

**`nx` itself.** `matchPackageNames` lists `@nrwl/*` and `@nx/*`; neither glob matches the unscoped `nx` package. Renovate has an open PR (#1629) proposing `nx` v20.8.4 — exactly the migration-less bump the rule exists to prevent.

**`angular-eslint`.** It is carried by `@nx/angular`'s `packageJsonUpdates` ladder in lockstep with `@angular/core`, so it has to move through `nx migrate` too. The shared `github>lacolaco/renovate-config:ng-update` preset does not reach it: that preset disables major/minor via `matchSourceUrlPrefixes: ["https://github.com/angular/angular"]` plus explicit name lists for `@angular/cli`, `@angular-devkit/*`, Material/CDK, TypeScript and rxjs. `angular-eslint` is published from `github.com/angular-eslint/angular-eslint`, so it matches neither the prefix nor any name list. Left unguarded, Renovate moves it off the version the ladder expects, which desynchronises the linter from the framework.

Config-only; nothing to run. Split out of the Nx/Angular upgrade branch so the upgrade PR carries only the upgrade.