### PR TITLE
fix: run project format targets from the repo root

### DIFF
--- a/apps/webapp/project.json
+++ b/apps/webapp/project.json
@@ -111,8 +111,7 @@
       "executor": "nx:run-commands",
       "inputs": ["default"],
       "options": {
-        "command": "npx prettier -w '.'",
-        "cwd": "apps/webapp"
+        "command": "npx prettier -w 'apps/webapp'"
       }
     }
   }

--- a/apps/worker/project.json
+++ b/apps/worker/project.json
@@ -43,8 +43,7 @@
       "executor": "nx:run-commands",
       "inputs": ["default"],
       "options": {
-        "command": "npx prettier -w '.'",
-        "cwd": "apps/worker"
+        "command": "npx prettier -w 'apps/worker'"
       }
     }
   }


### PR DESCRIPTION
`webapp` and `worker` both ran `npx prettier -w '.'` with `cwd` set to their own directory. Prettier resolves `.prettierignore` relative to its working directory, so the repo-root ignore file has never applied to either project.

The visible damage is in `worker`. The root ignore lists `pnpm-lock.yaml`, but `pnpm format` — the command `CLAUDE.md` names as canonical — rewrote it anyway. Measured on this branch: **499 changed lines before, zero after.**

That file is a deploy input. `.npmrc` sets `shared-workspace-lockfile=false` so the worker keeps its own lockfile, and production deploys `--source ./apps/worker` and resolves dependencies from it.

## The fix is at the root, not per project

Dropping `cwd` and passing the project path makes the repo-root `.prettierignore` authoritative for the whole workspace, which is the point of having one file. The alternative — adding `apps/worker/.prettierignore` — would have fixed the one symptom while leaving `webapp` on the same footing and creating a second ignore list to keep in sync with the first.

Two lines changed, one per project.

## Verification

`pnpm nx run worker:format` and `webapp:format`, both with `--skip-nx-cache`, leave `apps/worker/pnpm-lock.yaml` untouched. `pnpm format` across the workspace leaves the tree clean.

Split out of the Nx/Angular upgrade branch, where it was riding along as unrelated cargo.