### PR TITLE
fix(ci): build on a Go toolchain that includes the crypto/tls fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module contrib.rocks
 
-go 1.25.0
+go 1.25.12
 
 require (
 	cloud.google.com/go/bigquery v1.77.0


### PR DESCRIPTION
`govulncheck ./...` reports `GO-2026-5856` — an Encrypted Client Hello privacy leak in the standard library's `crypto/tls`. No dependency update closes it. It is fixed by the toolchain the binary is built with, and this repo builds with a toolchain that predates the fix by twelve patches.

## Why CI was pinned to an unpatched Go

The `setup-go` composite action passes `go-version-file: 'go.mod'` together with `check-latest: true`. That file's directive is the three-component `go 1.25.0`, and node-semver treats a full three-component version as an **exact match**, so `check-latest` has no range to search. The most recent CI run shows the result without ambiguity:

```
Setup go version spec 1.25.0
Successfully set up Go version 1.25.0
go version go1.25.0 linux/amd64
```

OSV records `GO-2026-5856` for the 1.25 series as `introduced 0` → `fixed 1.25.12`. So every image built by CI since #1692 moved the directive from `1.23.0` to `1.25.0` has shipped with the unpatched `crypto/tls`.

This PR sets the directive to `1.25.12`. It stays inside the 1.25 language version — nothing about the code's semantics changes — and it is the version `setup-go` will now request.

## A two-component directive would have been better, and is not possible

Writing `go 1.25` makes the spec a range, which is what `check-latest: true` wants: CI would then always take the newest 1.25 patch, and this class of problem would not recur. But `go mod tidy` normalises it straight back to `go 1.25.0` — verified by running it.

So `go.mod` cannot express a range, and CI's Go version is exactly pinned by construction. **The next standard-library advisory will open the same hole**, and closing it will again require someone to notice and bump by hand. Changing that means changing how CI selects Go at all (`go-version: 'stable'`, a scheduled bump, or something else) — an operational decision with ongoing consequences, deliberately left out of a security fix and tracked separately.

## Renovate was already pointing at this

#1658 proposed `toolchain go1.26.5`, which is the same fix from the other side. It lost its target when #1692 removed the `toolchain` line as redundant. Redundant to the Go tool, as it turned out; not redundant to CI.

## Verification

- `go build ./...`, `go vet ./...` — clean.
- `pnpm nx test golib --skip-nx-cache` — 13 packages ok. `pnpm nx test api --skip-nx-cache` — ok.
- `ko build --push=false ./apps/api` — succeeds.
- `go mod tidy` leaves `go 1.25.12` in place.
- `pnpm format` leaves the tree clean.

`govulncheck` locally still reports the advisory against `crypto/tls@go1.26.4`, because that is the toolchain on this machine; the check that matters is CI reporting `go version go1.25.12` on the next run, which is verifiable on this PR itself.

Stacks on #1693, which closes the last two module-level advisories.
