### PR TITLE
fix(deps): bump hono and @hono/node-server in worker to close their advisories

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@google-cloud/bigquery": "7.9.2",
     "@google-cloud/firestore": "7.11.0",
-    "@hono/node-server": "1.14.1",
-    "hono": "4.7.7"
+    "@hono/node-server": "1.19.17",
+    "hono": "4.12.33"
   }
 }

--- a/apps/worker/pnpm-lock.yaml
+++ b/apps/worker/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: 7.11.0
         version: 7.11.0
       '@hono/node-server':
-        specifier: 1.14.1
-        version: 1.14.1(hono@4.7.7)
+        specifier: 1.19.17
+        version: 1.19.17(hono@4.12.33)
       hono:
-        specifier: 4.7.7
-        version: 4.7.7
+        specifier: 4.12.33
+        version: 4.12.33
 
 packages:
 
@@ -60,8 +60,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@hono/node-server@1.14.1':
-    resolution: {integrity: sha512-vmbuM+HPinjWzPe7FFPWMMQMsbKE9gDPhaH0FFdqbGpkT5lp++tcWDTxwBl5EgS5y6JVgIaCdjeHRfQ4XRBRjQ==}
+  '@hono/node-server@1.19.17':
+    resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -301,8 +301,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.7.7:
-    resolution: {integrity: sha512-2PCpQRbN87Crty8/L/7akZN3UyZIAopSoRxCwRbJgUuV1+MHNFHzYFxZTg4v/03cXUm+jce/qa2VSBZpKBm3Qw==}
+  hono@4.12.33:
+    resolution: {integrity: sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ==}
     engines: {node: '>=16.9.0'}
 
   html-entities@2.5.2:
@@ -533,9 +533,9 @@ snapshots:
       protobufjs: 7.4.0
       yargs: 17.7.2
 
-  '@hono/node-server@1.14.1(hono@4.7.7)':
+  '@hono/node-server@1.19.17(hono@4.12.33)':
     dependencies:
-      hono: 4.7.7
+      hono: 4.12.33
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
@@ -790,7 +790,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.7.7: {}
+  hono@4.12.33: {}
 
   html-entities@2.5.2: {}
 


### PR DESCRIPTION
`apps/worker` runs on Cloud Run, so its dependencies are reachable at runtime — and it accounts for **97 of the repository's 109 open Dependabot alerts**. This closes the ones that do not need a major.

| | before | after | alerts |
| --- | --- | --- | --- |
| `hono` | 4.7.7 | 4.12.33 | 72 (10 high, 58 medium, 4 low) |
| `@hono/node-server` | 1.14.1 | 1.19.17 | 2 of 3 advisories |

`hono`'s highest `first_patched_version` across all 72 is 4.12.27, so a minor inside 4.x clears every one of them; 4.12.33 is the head of 4.x.

## `@hono/node-server`: all three fixes are in 1.x

The first draft of this PR deferred this package entirely, on the grounds that it needed the 2.x major. That was wrong, and wrong twice over — the aggregate "highest fixed version" hid what the individual advisories actually say.

| advisory | severity | fixed in |
| --- | --- | --- |
| `GHSA-wc8c-qw6v-h7f6` | high | 1.19.10 |
| `GHSA-92pp-h63x-v22m` | medium | 1.19.13 |
| `GHSA-frvp-7c67-39w9` | medium | 2.0.5 — **backported to 1.19.15** |

The third one was checked by unpacking the published artifacts rather than trusting the metadata. `dist/serve-static.mjs` ends its path check with `[\/\\]{2,}` in 1.19.13, and carries an additional `|\\` alternative in 1.19.15, 1.19.17 and 2.0.5 alike — the same one-line fix for a lone backslash.

**The alert will not clear regardless.** GitHub's advisory still records the vulnerable range as `< 2.0.5`, so no 1.x release satisfies it. Recorded here so that whoever evaluates 2.x later knows the code is already fixed and only the metadata disagrees. No exposure either way: this worker never calls `serveStatic`, and the vulnerability is Windows-only while Cloud Run is Linux.

## What is deliberately not here

The remaining worker alerts all sit behind `@google-cloud/bigquery` 7.9.2 → 8.x and `@google-cloud/firestore` 7.11.0 → 8.x, which should carry `protobufjs` (1 critical, 5 high, 5 medium), `@grpc/grpc-js` (2 high), `form-data` (1 critical, 1 high), `jws` (1 high) and `uuid` with them.

`apps/worker` has neither `test` nor `lint` — both targets are `echo` stubs — so nothing mechanical would catch a regression from a major. That bundle waits until either the test gap is closed or `/update-featured-repositories` gets exercised on staging by hand.

Renovate's #1678 proposes `@hono/node-server` 1.19.13; this supersedes it with a newer release in the same line.

## Verification

`.npmrc` sets `shared-workspace-lockfile=false`, so `apps/worker/pnpm-lock.yaml` is separate and must stay self-contained — production deploys `--source ./apps/worker` and resolves there. It has zero `link:`, `workspace:` or `../` references, and the root lockfile is untouched.

- `pnpm nx build worker --skip-nx-cache` — succeeds. `tsc --noEmit -p apps/worker/tsconfig.app.json` — clean.
- **The built `dist/main.js` was actually started**: it logs `Server running at http://127.0.0.1:3399/`, and `GET /nope` returns 404 with `{"error":"Not Found"}` — exercising routing, the catch-all, and `c.json` through the new versions of both packages.

The surface is small enough to say that is sufficient for the framework itself: `server.ts` is 31 lines and uses only `new Hono()`, `app.all`, `c.json`, and `serve`.

## Not verified

`/update-featured-repositories` queries BigQuery and writes to Firestore, so it is exercised on staging after merge — expecting 200 and a fresh `updatedAt` on both `featured_repositories` and `usage_stats` in the `staging` collection.

code-critic-reviewed: 055eaf7cfa698e3c8b468c771d615f26056bb4a3
