### PR TITLE
fix(api): return 404 for a missing repository instead of 500

### DIFF
--- a/apps/api/internal/api/image/api.go
+++ b/apps/api/internal/api/image/api.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -24,6 +25,12 @@ type ImageService interface {
 }
 
 type ContributorsService interface {
+	// GetContributors returns the repository's contributors.
+	//
+	// When the repository does not exist, the returned error must match
+	// *model.RepositoryNotFoundError under errors.As. Implementations may wrap it —
+	// the production one returns it inside a retry.Error — but must not replace it
+	// with an opaque error: Get maps that case to 404 and everything else to 500.
 	GetContributors(ctx context.Context, repo *model.Repository) (*model.RepositoryContributors, error)
 }
 
@@ -84,7 +91,9 @@ func (api *API) Get(c *gin.Context) {
 
 	// get data
 	data, err := api.cs.GetContributors(ctx, params.Repository.Object())
-	if notfound, ok := err.(*model.RepositoryNotFoundError); ok {
+	// retry-go wraps this in a retry.Error unless LastErrorOnly is set, so match through the wrapper.
+	var notfound *model.RepositoryNotFoundError
+	if errors.As(err, &notfound) {
 		log.Error(err.Error())
 		c.String(http.StatusNotFound, notfound.Error())
 		return

--- a/apps/api/internal/api/image/api_test.go
+++ b/apps/api/internal/api/image/api_test.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"contrib.rocks/apps/api/go/model"
 	"contrib.rocks/apps/api/go/renderer"
+	"contrib.rocks/apps/api/internal/apierror"
 	"contrib.rocks/apps/api/internal/config"
 	"contrib.rocks/apps/api/internal/logger"
 	"github.com/avast/retry-go/v4"
@@ -22,15 +24,18 @@ func (s *stubContributorsService) GetContributors(context.Context, *model.Reposi
 	return nil, s.err
 }
 
-// stubImageService always reports a cache miss so that Get reaches GetContributors.
+// stubImageService always reports a cache miss so that Get reaches GetContributors,
+// matching what internal/service/image returns when the cache has no entry.
 type stubImageService struct{}
 
 func (s *stubImageService) GetImage(context.Context, *model.Repository, *renderer.RendererOptions, bool) (model.FileHandle, error) {
 	return nil, nil
 }
 
+// RenderImage is never reached by these cases; fail loudly rather than returning
+// a nil handle that would panic further down in sendImage.
 func (s *stubImageService) RenderImage(context.Context, *model.RepositoryContributors, *renderer.RendererOptions, bool) (model.FileHandle, error) {
-	return nil, nil
+	return nil, errors.New("RenderImage should not be reached")
 }
 
 type stubUsageService struct{}
@@ -40,38 +45,49 @@ func (s *stubUsageService) CollectUsage(context.Context, *model.RepositoryContri
 }
 
 // newTestRouter wires the handler the way internal/server.go does, minus the
-// middleware that needs external services. errorHandler is reproduced here
-// because it is unexported in the parent package; keep it in step with it.
+// middleware that needs external services.
 func newTestRouter(contributorsErr error) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
+	r.Use(gin.Recovery())
 	r.Use(logger.Middleware(config.NewTestConfig()))
-	r.Use(func(c *gin.Context) {
-		c.Next()
-		if err := c.Errors.Last(); err != nil {
-			c.AbortWithStatusJSON(http.StatusInternalServerError, err.JSON())
-		}
-	})
+	r.Use(apierror.Middleware())
 	api := New(&stubContributorsService{err: contributorsErr}, &stubImageService{}, &stubUsageService{})
 	r.GET("/image", api.Get)
 	return r
 }
 
-// A missing repository must surface as 404, not 500. The error does not arrive
-// bare: HandleRepositoryNotFoundError returns retry.Unrecoverable, and
-// retry.Do wraps that in a retry.Error unless LastErrorOnly is set — which
-// GetRetryOptions does not set. A plain type assertion misses it and the
-// request falls through to the 500 handler.
+// A missing repository must surface as 404, not 500 — and everything else must
+// stay 500, since the match is by errors.As rather than by exact type.
+//
+// The not-found error does not arrive bare. HandleRepositoryNotFoundError returns
+// retry.Unrecoverable, and retry.Do records unpackUnrecoverable(err) — so the
+// Unrecoverable wrapper is stripped, but the surrounding retry.Error is not,
+// because GetRetryOptions does not set LastErrorOnly. The handler therefore sees
+// retry.Error{notFound}, which a plain type assertion misses.
+//
+// The wrapper is built by retry.Do rather than by hand so that this fixture
+// cannot drift from what production actually produces.
 func Test_Get_RepositoryNotFound(t *testing.T) {
 	repo := &model.Repository{Owner: "lacolaco", RepoName: "does-not-exist"}
 	notFound := &model.RepositoryNotFoundError{Repository: repo}
 
+	wrapped := retry.Do(func() error { return retry.Unrecoverable(notFound) })
+	if wrapped == nil {
+		t.Fatal("retry.Do returned nil, expected the error it was given")
+	}
+
 	tests := []struct {
 		name string
 		err  error
+		want int
+		// body must appear in the response, so that a status reached for the wrong
+		// reason — a panic recovered as 500, say — does not pass for the right one.
+		body string
 	}{
-		{"bare", notFound},
-		{"wrapped by retry.Do", retry.Error{retry.Unrecoverable(notFound)}},
+		{"bare", notFound, http.StatusNotFound, "lacolaco/does-not-exist"},
+		{"wrapped by retry.Do", wrapped, http.StatusNotFound, "lacolaco/does-not-exist"},
+		{"unrelated error stays 500", errors.New("github is unreachable"), http.StatusInternalServerError, "github is unreachable"},
 	}
 
 	for _, tt := range tests {
@@ -80,11 +96,11 @@ func Test_Get_RepositoryNotFound(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodGet, "/image?repo=lacolaco/does-not-exist", nil)
 			newTestRouter(tt.err).ServeHTTP(w, req)
 
-			if w.Code != http.StatusNotFound {
-				t.Fatalf("status = %d, want %d (body: %s)", w.Code, http.StatusNotFound, w.Body.String())
+			if w.Code != tt.want {
+				t.Fatalf("status = %d, want %d (body: %s)", w.Code, tt.want, w.Body.String())
 			}
-			if !strings.Contains(w.Body.String(), "lacolaco/does-not-exist") {
-				t.Fatalf("body = %q, want it to name the repository", w.Body.String())
+			if !strings.Contains(w.Body.String(), tt.body) {
+				t.Fatalf("body = %q, want it to contain %q", w.Body.String(), tt.body)
 			}
 		})
 	}

--- a/apps/api/internal/api/image/api_test.go
+++ b/apps/api/internal/api/image/api_test.go
@@ -1,0 +1,91 @@
+package image
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"contrib.rocks/apps/api/go/model"
+	"contrib.rocks/apps/api/go/renderer"
+	"contrib.rocks/apps/api/internal/config"
+	"contrib.rocks/apps/api/internal/logger"
+	"github.com/avast/retry-go/v4"
+	"github.com/gin-gonic/gin"
+)
+
+// stubContributorsService returns a fixed error from GetContributors.
+type stubContributorsService struct{ err error }
+
+func (s *stubContributorsService) GetContributors(context.Context, *model.Repository) (*model.RepositoryContributors, error) {
+	return nil, s.err
+}
+
+// stubImageService always reports a cache miss so that Get reaches GetContributors.
+type stubImageService struct{}
+
+func (s *stubImageService) GetImage(context.Context, *model.Repository, *renderer.RendererOptions, bool) (model.FileHandle, error) {
+	return nil, nil
+}
+
+func (s *stubImageService) RenderImage(context.Context, *model.RepositoryContributors, *renderer.RendererOptions, bool) (model.FileHandle, error) {
+	return nil, nil
+}
+
+type stubUsageService struct{}
+
+func (s *stubUsageService) CollectUsage(context.Context, *model.RepositoryContributors, string) error {
+	return nil
+}
+
+// newTestRouter wires the handler the way internal/server.go does, minus the
+// middleware that needs external services. errorHandler is reproduced here
+// because it is unexported in the parent package; keep it in step with it.
+func newTestRouter(contributorsErr error) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(logger.Middleware(config.NewTestConfig()))
+	r.Use(func(c *gin.Context) {
+		c.Next()
+		if err := c.Errors.Last(); err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, err.JSON())
+		}
+	})
+	api := New(&stubContributorsService{err: contributorsErr}, &stubImageService{}, &stubUsageService{})
+	r.GET("/image", api.Get)
+	return r
+}
+
+// A missing repository must surface as 404, not 500. The error does not arrive
+// bare: HandleRepositoryNotFoundError returns retry.Unrecoverable, and
+// retry.Do wraps that in a retry.Error unless LastErrorOnly is set — which
+// GetRetryOptions does not set. A plain type assertion misses it and the
+// request falls through to the 500 handler.
+func Test_Get_RepositoryNotFound(t *testing.T) {
+	repo := &model.Repository{Owner: "lacolaco", RepoName: "does-not-exist"}
+	notFound := &model.RepositoryNotFoundError{Repository: repo}
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"bare", notFound},
+		{"wrapped by retry.Do", retry.Error{retry.Unrecoverable(notFound)}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodGet, "/image?repo=lacolaco/does-not-exist", nil)
+			newTestRouter(tt.err).ServeHTTP(w, req)
+
+			if w.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want %d (body: %s)", w.Code, http.StatusNotFound, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), "lacolaco/does-not-exist") {
+				t.Fatalf("body = %q, want it to name the repository", w.Body.String())
+			}
+		})
+	}
+}

--- a/apps/api/internal/apierror/middleware.go
+++ b/apps/api/internal/apierror/middleware.go
@@ -1,0 +1,26 @@
+// Package apierror turns errors that handlers record with c.Error into HTTP responses.
+//
+// It lives outside internal/app so that handler packages can exercise the real
+// middleware in their tests rather than reproducing it.
+package apierror
+
+import (
+	"net/http"
+
+	"contrib.rocks/apps/api/internal/logger"
+	"github.com/gin-gonic/gin"
+)
+
+// Middleware responds 500 with the last error a handler recorded via c.Error.
+// Handlers that want a different status write the response themselves and return.
+func Middleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+		err := c.Errors.Last()
+		if err == nil {
+			return
+		}
+		logger.LoggerFromContext(c.Request.Context()).Error(err.Error())
+		c.AbortWithStatusJSON(http.StatusInternalServerError, err.JSON())
+	}
+}

--- a/apps/api/internal/server.go
+++ b/apps/api/internal/server.go
@@ -3,11 +3,11 @@ package app
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 
 	"contrib.rocks/apps/api/go/compress"
 	"contrib.rocks/apps/api/go/env"
 	"contrib.rocks/apps/api/internal/api"
+	"contrib.rocks/apps/api/internal/apierror"
 	"contrib.rocks/apps/api/internal/config"
 	"contrib.rocks/apps/api/internal/logger"
 	"contrib.rocks/apps/api/internal/service"
@@ -37,7 +37,7 @@ func StartServer() error {
 	r.Use(config.Middleware(cfg))
 	r.Use(tracing.Middleware(cfg))
 	r.Use(logger.Middleware(cfg))
-	r.Use(errorHandler())
+	r.Use(apierror.Middleware())
 	r.Use(requestLogger())
 	r.Use(compress.Compress())
 
@@ -45,18 +45,6 @@ func StartServer() error {
 
 	fmt.Printf("Listening on http://localhost:%s\n", cfg.Port)
 	return r.Run(fmt.Sprintf(":%s", cfg.Port))
-}
-
-func errorHandler() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		c.Next()
-		err := c.Errors.Last()
-		if err == nil {
-			return
-		}
-		logger.LoggerFromContext(c.Request.Context()).Error(err.Error())
-		c.AbortWithStatusJSON(http.StatusInternalServerError, err.JSON())
-	}
 }
 
 func requestLogger() gin.HandlerFunc {


### PR DESCRIPTION
`GET /image?repo=…` returns **500 for a repository that does not exist**, where the handler plainly intends 404 and `Repository not found: owner/repo`. For a service embedded in READMEs, a typo'd, renamed, private or deleted repository is the most common failure there is, and GitHub's camo proxy has been getting a server error for all of them.

Reproduced against a locally-running API before touching anything:

```
$ curl -s -w '%{http_code}' 'localhost:3333/image?repo=lacolaco/this-repo-does-not-exist-xyz'
500
{"error":"All attempts fail:\n#1: Repository not found: lacolaco/this-repo-does-not-exist-xyz"}
```

## The error never arrives in the shape the handler tested for

`internal/api/image/api.go` asserted the concrete type:

```go
if notfound, ok := err.(*model.RepositoryNotFoundError); ok {
```

`HandleRepositoryNotFoundError` returns `retry.Unrecoverable(&model.RepositoryNotFoundError{…})`, and `api.Call` returns that through `retry.Do`. `GetRetryOptions` does not set `retry.LastErrorOnly(true)`, and retry-go v4's default for it is false, so the return is always a `retry.Error` (`type Error []error`). The assertion therefore never succeeds, the request falls through to `c.Error(err)`, and the error middleware — which does not inspect the type — turns it into a 500.

Matching with `errors.As` instead. `retry.Error` implements `As` by walking its elements, so this keeps working if another layer is added.

## Why the tests are in the same change

`Get` had **0.0% coverage**; the HTTP layer had no test at all. The identical check in the service layer *is* written with `errors.As` (`contributors/github_test.go`), so the author who knew about the wrapping tested the layer that had tests, and the layer without them kept the bug. Fixing the line without closing that gap restores the exact conditions that produced it.

The table runs the not-found error in both shapes plus an unrelated error, and asserts the body as well as the status so that a 500 reached by some other route — a recovered panic, say — cannot pass as the intended one. Reverting the line to a type assertion fails only `wrapped_by_retry.Do`, with the same body observed in production.

**The wrapper is built by `retry.Do` rather than by hand.** An earlier draft used `retry.Error{retry.Unrecoverable(notFound)}`, which production never produces: `retry.Do` appends `unpackUnrecoverable(err)`, stripping the `Unrecoverable` shell, so the handler actually sees `retry.Error{notFound}`. Measured with a throwaway probe — `outer=retry.Error`, `len=1`, `[0]=*model.RepositoryNotFoundError`. Letting `retry.Do` build the fixture means it cannot drift from that.

## Three commits

- `fix(api):` the `errors.As` change and its regression test, plus the postcondition this bug came from being unwritten — `ContributorsService.GetContributors` now documents that a missing repository must stay matchable under `errors.As`, may be wrapped, and must not be replaced by an opaque error. Nothing in the signature said so, which is why a caller could get it wrong by reading only the signature.
- `refactor(api):` `errorHandler` moves out of `internal/app` into `internal/apierror`. It was unexported in the composition root, so a handler test could not reach it without an import cycle and had to copy it — and the copy was already missing the log line the original emits. Function body is byte-identical after the move; the only other change is the call site and an import that became unused.
- `test(api):` the test then uses the real middleware.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l apps/api` — clean.
- `pnpm nx test golib --skip-nx-cache` — 13 packages ok. `pnpm nx test api --skip-nx-cache` — ok. `pnpm lint` — passes.
- `ko build --push=false ./apps/api` — succeeds.
- `internal/api/image` coverage 0.0% → **65.6%** for `Get`'s package.

## Not verified

Staging after merge: `https://stg.contrib.rocks/image?repo=<nonexistent>` returning 404 with the repository named, and a real repository still rendering.

## Found while working on this, not fixed here

`saveFile` in `appcache/gcs.go` discards the error from `storage.Writer.Close()`, which is the only place a failed GCS upload is reported — a silent cache-write failure. Tracked separately; it does not trace back to this change.

code-critic-reviewed: 343cd6e96720bc6fb272c98227b692213936785c
