### PR TITLE
fix(api): surface GCS upload failures instead of swallowing them

### DIFF
--- a/apps/api/internal/service/contributors/service.go
+++ b/apps/api/internal/service/contributors/service.go
@@ -51,9 +51,8 @@ func (s *Service) GetContributors(c context.Context, r *model.Repository) (*mode
 		return nil, err
 	}
 	// save cache
-	err = s.cache.SaveJSON(ctx, cacheKey, data)
-	if err != nil {
-		return nil, err
+	if err := s.cache.SaveJSON(ctx, cacheKey, data); err != nil {
+		cacheutil.LogCacheSaveFailure(ctx, "contributors-json", cacheKey, err)
 	}
 	return data, nil
 }

--- a/apps/api/internal/service/contributors/service_test.go
+++ b/apps/api/internal/service/contributors/service_test.go
@@ -1,0 +1,70 @@
+package contributors
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"contrib.rocks/apps/api/go/model"
+	"contrib.rocks/apps/api/internal/logger"
+	"github.com/google/go-github/v69/github"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+type stubProvider struct{ client *github.Client }
+
+func (p *stubProvider) Get() *github.Client { return p.client }
+
+// mockCache reports a miss on read and a failure on write.
+type mockCache struct{ saveJSONErr error }
+
+func (m *mockCache) Get(context.Context, string) (model.FileHandle, error) { return nil, nil }
+func (m *mockCache) GetJSON(context.Context, string, any) error            { return nil }
+func (m *mockCache) Save(context.Context, string, []byte, string) error    { return nil }
+func (m *mockCache) SaveJSON(context.Context, string, any) error           { return m.saveJSONErr }
+
+// A cache write that fails must not fail the request. The data in hand was paid
+// for with GitHub API quota — the scarcest resource this service has — so
+// discarding it because GCS refused a write means the next request buys it
+// again. Worse, a persistent write failure would then burn the hourly limit and
+// take the service down for a reason unrelated to the actual fault.
+func TestService_GetContributors_cacheSaveFailureIsNotFatal(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/test-owner/test-repo", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"stargazers_count":42,"owner":{"login":"test-owner"},"name":"test-repo"}`))
+	})
+	mux.HandleFunc("/repos/test-owner/test-repo/contributors", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"id":1,"login":"user1","avatar_url":"https://avatar1.example"}]`))
+	})
+	ghclient, _ := setup(t, mux)
+
+	service := New(&stubProvider{client: ghclient}, &mockCache{
+		saveJSONErr: errors.New("googleapi: Error 403: quota exceeded"),
+	})
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	ctx := logger.ContextWithLogger(context.Background(), zap.New(core))
+
+	data, err := service.GetContributors(ctx, &model.Repository{Owner: "test-owner", RepoName: "test-repo"})
+	if err != nil {
+		t.Fatalf("err = %v, want nil: a failed cache write must not fail the request", err)
+	}
+	if data == nil || len(data.Contributors) != 1 {
+		t.Fatalf("data = %+v, want the contributors fetched from GitHub", data)
+	}
+
+	// The write still has to be reported, or the failure is invisible again.
+	errorLogs := logs.FilterLevelExact(zapcore.ErrorLevel).All()
+	if len(errorLogs) != 1 {
+		t.Fatalf("error logs = %d, want 1: the failure must still be recorded", len(errorLogs))
+	}
+	if !strings.Contains(errorLogs[0].Message, "contributors-json-cache-save-failure") {
+		t.Fatalf("log = %q, want it to name the cache-save-failure group", errorLogs[0].Message)
+	}
+}

--- a/apps/api/internal/service/image/service.go
+++ b/apps/api/internal/service/image/service.go
@@ -64,9 +64,8 @@ func (s *Service) RenderImage(c context.Context, data *model.RepositoryContribut
 
 	image := renderer.NewRenderer(options).Render(data)
 
-	err = s.cache.Save(c, cacheKey, image.Bytes(), image.ContentType())
-	if err != nil {
-		return nil, err
+	if err := s.cache.Save(ctx, cacheKey, image.Bytes(), image.ContentType()); err != nil {
+		cacheutil.LogCacheSaveFailure(ctx, "image", cacheKey, err)
 	}
 	return image, nil
 }

--- a/apps/api/internal/service/image/service_test.go
+++ b/apps/api/internal/service/image/service_test.go
@@ -2,10 +2,16 @@ package image
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"contrib.rocks/apps/api/go/model"
 	"contrib.rocks/apps/api/go/renderer"
+	"contrib.rocks/apps/api/internal/logger"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // mockCache is a simple implementation of appcache.AppCache for testing
@@ -121,4 +127,59 @@ func TestService_normalizeContributors(t *testing.T) {
 			}
 		}
 	})
+}
+
+// A cache write that fails must not fail the request. By the time Save runs the
+// image is already rendered, and the contributors it was rendered from cost
+// GitHub API quota to fetch; discarding all of that because GCS refused a write
+// turns a latency problem into an outage. The failure is logged instead, so it
+// stays visible without taking the response with it.
+func TestService_RenderImage_cacheSaveFailureIsNotFatal(t *testing.T) {
+	originalConverter := dataURLConverter
+	dataURLConverter = mockDataURLConverter
+	defer func() { dataURLConverter = originalConverter }()
+
+	var savedKey string
+	service := &Service{
+		cache: &mockCache{
+			saveFunc: func(_ context.Context, key string, _ []byte, _ string) error {
+				savedKey = key
+				return errors.New("googleapi: Error 403: quota exceeded")
+			},
+		},
+	}
+
+	data := &model.RepositoryContributors{
+		Repository:      &model.Repository{Owner: "test-owner", RepoName: "test-repo"},
+		StargazersCount: 100,
+		Contributors:    []*model.Contributor{{ID: 1, Login: "user1", AvatarURL: "https://avatar1.com"}},
+	}
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	ctx := logger.ContextWithLogger(context.Background(), zap.New(core))
+
+	image, err := service.RenderImage(ctx, data, &renderer.RendererOptions{}, false)
+	if err != nil {
+		t.Fatalf("err = %v, want nil: a failed cache write must not fail the request", err)
+	}
+	if image == nil {
+		t.Fatal("image = nil, want the rendered image")
+	}
+	if image.Size() == 0 {
+		t.Fatal("image is empty, want rendered SVG bytes")
+	}
+	if savedKey == "" {
+		t.Fatal("Save was never called; the test did not exercise the failure path")
+	}
+
+	// Not failing the request is only half the contract. Dropping the log as well
+	// would restore the bug this change exists to remove: a write that never
+	// landed, reported nowhere.
+	errorLogs := logs.FilterLevelExact(zapcore.ErrorLevel).All()
+	if len(errorLogs) != 1 {
+		t.Fatalf("error logs = %d, want 1: the failure must still be recorded", len(errorLogs))
+	}
+	if !strings.Contains(errorLogs[0].Message, savedKey) {
+		t.Fatalf("log = %q, want it to name the cache key %q", errorLogs[0].Message, savedKey)
+	}
 }

--- a/apps/api/internal/service/internal/appcache/gcs.go
+++ b/apps/api/internal/service/internal/appcache/gcs.go
@@ -129,10 +129,14 @@ func saveFile(bucket *storage.BucketHandle, c context.Context, name string, data
 	span.SetAttributes(attribute.String("cache.object.name", name))
 
 	w := bucket.Object(name).NewWriter(ctx)
-	defer w.Close()
 	w.ContentType = contentType
-	_, err := w.Write(data)
-	return err
+	if _, err := w.Write(data); err != nil {
+		w.Close()
+		return err
+	}
+	// Write only fills the writer's internal pipe. Whether the upload succeeded is
+	// reported by Close alone, so its error is the one that matters here.
+	return w.Close()
 }
 
 var _ model.FileHandle = &gcsFileHandle{}

--- a/apps/api/internal/service/internal/appcache/gcs_save_test.go
+++ b/apps/api/internal/service/internal/appcache/gcs_save_test.go
@@ -1,0 +1,56 @@
+package appcache
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/option"
+)
+
+// newBucketAgainst points a storage client at a local test server, so that the
+// upload path can be exercised without credentials or a real bucket.
+func newBucketAgainst(t *testing.T, h http.Handler) *storage.BucketHandle {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	client, err := storage.NewClient(context.Background(),
+		option.WithEndpoint(srv.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("storage.NewClient: %v", err)
+	}
+	t.Cleanup(func() { client.Close() })
+	return client.Bucket("test-bucket")
+}
+
+// A failed upload must reach the caller. storage.Writer.Write only fills an
+// internal pipe and reports nothing about the transfer; the result is delivered
+// by Close. Discarding Close's error makes every write failure — credentials,
+// quota, network, checksum — look like a successful cache save, so the entry is
+// missed on every subsequent request with nothing logged and nothing returned.
+func Test_saveFile_uploadFailure(t *testing.T) {
+	bucket := newBucketAgainst(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":{"code":403,"message":"quota exceeded"}}`, http.StatusForbidden)
+	}))
+
+	err := saveFile(bucket, context.Background(), "image/foo--bar.svg", []byte("<svg/>"), "image/svg+xml")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Fatalf("err = %v, want it to mention the 403 from the server", err)
+	}
+}
+
+// A nil bucket means the cache is disabled, not that saving failed.
+func Test_saveFile_nilBucket(t *testing.T) {
+	if err := saveFile(nil, context.Background(), "image/foo--bar.svg", []byte("<svg/>"), "image/svg+xml"); err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+}

--- a/apps/api/internal/service/internal/cacheutil/logs.go
+++ b/apps/api/internal/service/internal/cacheutil/logs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"contrib.rocks/apps/api/internal/logger"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // LogCacheMiss logs cache miss events in a standardized format
@@ -13,5 +14,20 @@ func LogCacheMiss(ctx context.Context, cacheType string, key string) {
 	logGroup := fmt.Sprintf("%s-cache-miss", cacheType)
 	logger.LoggerFromContext(ctx).With(logger.LogGroup(logGroup)).Info(
 		fmt.Sprintf("%s: %s", logGroup, key),
+	)
+}
+
+// LogCacheSaveFailure records a cache write that did not land.
+//
+// Callers log rather than propagate: the response is already computed by this
+// point, and failing the request would throw away work that succeeded — a
+// rendered image, or contributor data that cost GitHub API quota to fetch. The
+// cost of a lost write is latency on later requests, so it belongs in the logs,
+// not in the status code.
+func LogCacheSaveFailure(ctx context.Context, cacheType string, key string, err error) {
+	trace.SpanFromContext(ctx).RecordError(err)
+	logGroup := fmt.Sprintf("%s-cache-save-failure", cacheType)
+	logger.LoggerFromContext(ctx).With(logger.LogGroup(logGroup)).Error(
+		fmt.Sprintf("%s: %s: %s", logGroup, key, err),
 	)
 }


### PR DESCRIPTION
`saveFile` threw away the only signal a GCS upload gives you, so a cache that silently stopped accepting writes looked exactly like one that was working.

```go
w := bucket.Object(name).NewWriter(ctx)
defer w.Close()
w.ContentType = contentType
_, err := w.Write(data)
return err
```

`storage.Writer.Write` only feeds the writer's internal pipe — its own doc says *"Write may return a nil error even though the write failed. Always use the error returned from Writer.Close"*. `Close` is what waits on the upload and reports it, and `defer` runs after `return err` is evaluated, so without a named return that error is unreachable. Every failure mode — credentials, quota, network, and now checksum, since #1692 turned on `EnableAutoChecksum` — returned `nil` to the caller.

The effect is not a lost write; it is a permanently cold key. `CLAUDE.md` calls this cache load-bearing rather than an optimisation, and rightly: every miss re-fetches one avatar per contributor. A key that never lands pays that on every request, forever, with nothing logged, nothing returned, and no self-healing.

Now returning `Close`'s error (and `Write`'s, if it fails first, after closing the writer).

## Reporting the failure is the point; failing the request is not

Returning the error is only half the change, and the other half is a decision rather than a fix. Propagating it means `RenderImage` throws away an image it has already rendered, and `GetContributors` throws away data it just spent GitHub API quota to fetch — the scarcest resource this service has. A persistent write failure would then burn the hourly limit and take the service down for a reason unrelated to the actual fault.

Read failures already return 500, so a dead cache was already an outage. What this would newly break is the *readable-but-not-writable* class — a service account without `storage.objects.create`, a retention policy, a write-side quota — where the behaviour today is "slower, but working". And because `saveFile` runs on the request context, a camo proxy timing out mid-request would surface `context.Canceled` as a server error on a connection that is already gone.

So both call sites log and continue. `cacheutil.LogCacheSaveFailure` mirrors the existing `LogCacheMiss` — same shape, same `logGroup` convention (`image-cache-save-failure`, `contributors-json-cache-save-failure`), landing in `logging.googleapis.com/labels.groupId` like `repository-usage` does — and records the error on the OTel span too, so both callers get it without repeating themselves.

Detection is not lost by this: a write outage amplifies itself into latency and GitHub quota pressure until it becomes impossible to miss, whereas a 500 would break every README embedding the image worldwide.

## Tests

`appcache` had one test and no coverage of the write path at all. Pointing `storage.NewClient` at an `httptest` server with `option.WithEndpoint` + `option.WithoutAuthentication` exercises the real multipart upload without credentials or a bucket — verified that the request actually arrives as `POST /upload/storage/v1/b/test-bucket/o?...uploadType=multipart`, that a 403 surfaces as `*googleapi.Error`, and that a 200 handler returns `nil`.

Each behaviour is pinned by checking that removing it fails the test:

| revert | fails with |
| --- | --- |
| `defer w.Close()` | `expected error, got nil` |
| propagate instead of log | `want nil: a failed cache write must not fail the request` |
| drop the log line | `error logs = 0, want 1: the failure must still be recorded` |

That last one matters most. An earlier draft only asserted that the request survived, which meant deleting the log call still passed — reinstating the original bug one layer up. Both service tests now assert the ERROR log via `zaptest/observer`.

The `contributors` side is pinned too, not just `image`; it is the path that loses more.

## Also

`image/service.go` was passing `c` rather than the span-carrying `ctx` to `Save`, so the `appcache.Save` span never attached to `RenderImage`. Fixed while the line was being touched; `contributors` already used `ctx`.

## Not covered here

There is **no alerting on these log groups** — the repository contains no GCP monitoring config, so "visible" currently means "findable if you go looking". Worth a log-based metric on `labels.groupId="image-cache-save-failure"`, measured as a ratio rather than a threshold, since a write outage emits one ERROR per request at camo traffic volumes.

Other swallowed errors found while reading this code are filed separately rather than bundled — most notably that avatar fetching never checks the response status, so a 404's HTML body gets base64-embedded into the SVG as if it were an image.

code-critic-reviewed: 89412999528083f495dd43bc9d2e53728c0cfb13
